### PR TITLE
Add open-backport-pull-request

### DIFF
--- a/.github/workflows/open-backport-pull-request.yaml
+++ b/.github/workflows/open-backport-pull-request.yaml
@@ -1,0 +1,39 @@
+name: open-backport-pull-request
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - open-backport-pull-request/**
+      - '*.json'
+      - .github/workflows/open-backport-pull-request.yaml
+  pull_request:
+    branches: [main]
+    paths:
+      - open-backport-pull-request/**
+      - '*.json'
+      - .github/workflows/open-backport-pull-request.yaml
+
+jobs:
+  ts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: open-backport-pull-request
+    steps:
+      - uses: actions/checkout@v2
+      - id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn
+      - run: yarn lint
+      - run: yarn format-check
+      - run: yarn test
+      - run: yarn build
+      - run: yarn package

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ destination-repository  (branch: ns/${source-repository}/${overlay}/${namespace}
 | [git-push-namespace](git-push-namespace) | Push an Argo CD Application for namespace | [![git-push-namespace](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-push-namespace.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-push-namespace.yaml)
 | [git-delete-namespace-application](git-delete-namespace-application) | Delete Argo CD Applications of pull request namespaces | [![git-delete-namespace-application](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-delete-namespace-application.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-delete-namespace-application.yaml)
 | [git-delete-namespace-branch](git-delete-namespace-branch) | Delete branches of pull request namespaces | [![git-delete-namespace-branch](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-delete-namespace-branch.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/git-delete-namespace-branch.yaml)
+| [open-backport-pull-request](open-backport-pull-request) | Open Backport Pull Requests from a specific branch | [![open-backport-pull-request](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/open-backport-pull-request.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/open-backport-pull-request.yaml)
 
 
 ## Release strategy

--- a/open-backport-pull-request/README.md
+++ b/open-backport-pull-request/README.md
@@ -1,0 +1,45 @@
+# open-backport-pull-request
+
+This is an action to open Backport Pull Requests from a specific branch.
+
+This is useful in branching strategies like Gitflow, where a hotfix to the `main` branch needs to be backported to the `develop` branch afterwards.
+
+## Usage
+
+```yaml
+on:
+  push:
+    branches:
+      - 'main'
+      - '*/main'
+
+  workflow_dispatch:
+    inputs:
+      headBranch:
+        description: Target branch to backport from
+        required: true
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    steps:
+      - id: backport
+        name: Open Backport Pull Request
+        uses: quipper/monorepo-deploy-actions/open-backport-pull-request@v1
+        with:
+          base-branch: develop
+```
+
+## Inputs
+
+| Name           | Required | Default         | Description
+|----------------|----------|-----------------|----------------------------------------------
+| `github-token` | `true`   | `$github.token` | GitHub token used for opening a Pull Request
+| `base-branch`  | `true`   |                 | Base branch of the Pull Request
+
+
+## Outputs
+
+| Name               | Description
+|--------------------|-------------------------------
+| `pull-request-url` | URL of the opened Pull Request

--- a/open-backport-pull-request/action.yaml
+++ b/open-backport-pull-request/action.yaml
@@ -1,0 +1,15 @@
+name: open-backport-pull-request
+description: Open backport Pull Requests
+inputs:
+  github-token:
+    description: GitHub token used for opening a Pull Request
+    default: ${{ github.token }}
+  base-branch:
+    description: The base branch for a Pull Request
+    required: true
+outputs:
+  pull-request-url:
+    description: The URL of the opened Pull Request
+runs:
+  using: 'node12'
+  main: 'dist/index.js'

--- a/open-backport-pull-request/jest.config.js
+++ b/open-backport-pull-request/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  clearMocks: true,
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  verbose: true
+}

--- a/open-backport-pull-request/package.json
+++ b/open-backport-pull-request/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "open-backport-pull-request-action",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Open Backport Pull Request action",
+  "main": "lib/src/main.js",
+  "scripts": {
+    "build": "tsc",
+    "format": "prettier --write **/*.ts",
+    "format-check": "prettier --check **/*.ts",
+    "lint": "eslint **/*.ts",
+    "package": "ncc build --source-map --license licenses.txt",
+    "test": "jest",
+    "ci:package": "yarn build && yarn package"
+  },
+  "dependencies": {
+    "@actions/core": "1.5.0"
+  }
+}

--- a/open-backport-pull-request/src/main.ts
+++ b/open-backport-pull-request/src/main.ts
@@ -1,0 +1,11 @@
+import * as core from '@actions/core'
+import { run } from './run'
+
+const main = async (): Promise<void> => {
+  await run({
+    githubToken: core.getInput('github-token', { required: true }),
+    baseBranch: core.getInput('base-branch', { required: true }),
+  })
+}
+
+main().catch((error) => core.setFailed(error))

--- a/open-backport-pull-request/src/run.ts
+++ b/open-backport-pull-request/src/run.ts
@@ -1,0 +1,80 @@
+import * as core from '@actions/core'
+import { context, getOctokit } from '@actions/github'
+import { Context } from '@actions/github/lib/context'
+import { GitHub } from '@actions/github/lib/utils'
+
+type Octokit = InstanceType<typeof GitHub>
+
+interface Inputs {
+  githubToken: string
+  baseBranch: string
+}
+
+export const run = async (inputs: Inputs): Promise<void> => {
+  const headBranch = getHeadBranch(context)
+  const baseBranch = inputs.baseBranch
+  const octokit = getOctokit(inputs.githubToken)
+
+  if (await hasDiff({ headBranch, baseBranch, octokit, context })) {
+    const pullRequestUrl = await openPullRequest({
+      headBranch,
+      baseBranch,
+      octokit,
+      context,
+    })
+    core.setOutput('pull-request-url', pullRequestUrl)
+  }
+}
+
+export const getHeadBranch = (context: Context): string => {
+  if (context.eventName === 'workflow_dispatch') {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return context.payload.inputs.headBranch as string
+  } else {
+    return context.ref.replace(/^refs\/heads\//, '')
+  }
+}
+
+type hasDiffParams = {
+  headBranch: string
+  baseBranch: string
+  context: Context
+  octokit: Octokit
+}
+const hasDiff = async (params: hasDiffParams): Promise<boolean> => {
+  const compare = await params.octokit.request('GET /repos/{owner}/{repo}/compare/{basehead}', {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    basehead: `${params.baseBranch}...${params.headBranch}`,
+  })
+  return !!(compare.data.files && compare.data.files.length > 0)
+}
+
+type openPullRequestParams = {
+  headBranch: string
+  baseBranch: string
+  context: Context
+  octokit: Octokit
+}
+const openPullRequest = async (params: openPullRequestParams): Promise<string | undefined> => {
+  try {
+    const pr = await params.octokit.rest.pulls.create({
+      owner: params.context.repo.owner,
+      repo: params.context.repo.repo,
+      head: params.headBranch,
+      base: params.baseBranch,
+      title: `Backport ${params.headBranch} into ${params.baseBranch}`,
+      body: `Created from https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+    })
+    return pr.data.html_url
+  } catch (err) {
+    console.error(err)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (typeof err === 'object' && err.status === 422) {
+      core.warning('Pull Request already exists')
+    } else {
+      core.error('Unknown failure: ${err.message}')
+    }
+  }
+}

--- a/open-backport-pull-request/tests/run.test.ts
+++ b/open-backport-pull-request/tests/run.test.ts
@@ -1,0 +1,34 @@
+import { getHeadBranch } from '../src/run'
+import { Context } from '@actions/github/lib/context'
+
+describe('#getHeadBranch', () => {
+  describe('when workflow_dispatch event', () => {
+    test('run successfully', () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const context = {
+        eventName: 'workflow_dispatch',
+        payload: {
+          inputs: {
+            headBranch: 'foo-branch',
+          },
+        },
+      } as Context
+      const headBranch = getHeadBranch(context)
+      expect(headBranch).toEqual('foo-branch')
+    })
+  })
+
+  describe('when push event', () => {
+    test('run successfully', () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const context = {
+        eventName: 'push',
+        ref: 'refs/heads/bar-branch',
+      } as Context
+      const headBranch = getHeadBranch(context)
+      expect(headBranch).toEqual('bar-branch')
+    })
+  })
+})

--- a/open-backport-pull-request/tsconfig.json
+++ b/open-backport-pull-request/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDirs": ["./src"],
+  }
+}


### PR DESCRIPTION
This is useful in branching strategies like Gitflow, where a hotfix to the `main` branch needs to be backported to the `develop` branch afterwards.

Previously, implemented it as a GitHub Workflow using `actions/github-scripts` action:

<details>
<summary>Previous implementation</summary>

```yaml
jobs:
  backport:
    runs-on: ubuntu-latest
    env:
      BACKPORT_BASE_BRANCH: 'develop'
    steps:
      - id: backport-head-branch
        name: Decide head branch to backport from
        uses: actions/github-script@v4
        with:
          result-encoding: string
          script: |
            if (context.eventName === 'workflow_dispatch') {
              return '${{ github.event.inputs.headBranch }}';
            } else {
              return '${{ github.ref }}'.replace(/^refs\/heads\//, '');
            }
      - id: has-diff
        name: Check if the branches have diffs
        uses: actions/github-script@v4
        with:
          script: |
            const compare = await github.request('GET /repos/{owner}/{repo}/compare/{basehead}', {
              owner: context.repo.owner,
              repo: context.repo.repo,
              basehead: '${{ env.BACKPORT_BASE_BRANCH }}...${{ steps.backport-head-branch.outputs.result }}'
            });
            return compare.data.files.length > 0;
      - id: backport
        name: Open a backport Pull Request
        if: ${{ steps.has-diff.outputs.result == 'true' }}
        uses: actions/github-script@v4
        with:
          result-encoding: string
          script: |
            try {
              const pr = await github.pulls.create({
                owner: context.repo.owner,
                repo: context.repo.repo,
                head: '${{ steps.backport-head-branch.outputs.result }}',
                base: '${{ env.BACKPORT_BASE_BRANCH }}',
                title: 'Backport ${{ steps.backport-head-branch.outputs.result }} into ${{ env.BACKPORT_BASE_BRANCH }}',
                body: 'Created from https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}',
              });
              return pr.data.html_url;
            } catch (err) {
              console.error(err);
              if (err.status === 422) {
                core.warning('Pull Request already exists');
                return '';
              } else {
                core.error("Unknown failure: ${err.message}");
              }
            }
```
</details>

This time, I ported it into an Action implemented with TypeScript.

This can be used like this.
It got quite concize:

```yaml
jobs:
  backport:
    runs-on: ubuntu-latest
    steps:
      - id: backport
        name: Open Backport Pull Request
        uses: quipper/monorepo-deploy-actions/open-backport-pull-request@v1
        with:
          base-branch: develop
```

I tested it in a repository and it worked as I expected:
https://github.com/yuya-takeyama/test/pull/24
https://github.com/yuya-takeyama/test/actions/runs/1155174077