### PR TITLE
Add more outputs to open-backport-pull-request

### DIFF
--- a/open-backport-pull-request/README.md
+++ b/open-backport-pull-request/README.md
@@ -41,5 +41,7 @@ jobs:
 ## Outputs
 
 | Name               | Description
-|--------------------|-------------------------------
+|--------------------|--------------------------------------------
 | `pull-request-url` | URL of the opened Pull Request
+| `base-branch`      | The base branch of the opened Pull Request 
+| `head-branch`      | The head branch of the opened Pull Request

--- a/open-backport-pull-request/action.yaml
+++ b/open-backport-pull-request/action.yaml
@@ -10,6 +10,10 @@ inputs:
 outputs:
   pull-request-url:
     description: The URL of the opened Pull Request
+  base-branch:
+    description: The base branch of the opened Pull Request
+  head-branch:
+    description: The head branch of the opened Pull Request
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/open-backport-pull-request/src/run.ts
+++ b/open-backport-pull-request/src/run.ts
@@ -15,6 +15,9 @@ export const run = async (inputs: Inputs): Promise<void> => {
   const baseBranch = inputs.baseBranch
   const octokit = getOctokit(inputs.githubToken)
 
+  core.setOutput('base-branch', baseBranch)
+  core.setOutput('head-branch', headBranch)
+
   if (await hasDiff({ headBranch, baseBranch, octokit, context })) {
     const pullRequestUrl = await openPullRequest({
       headBranch,


### PR DESCRIPTION
This is useful when sending a notification based on the result of the action.
Slack notification example:

```yaml
    steps:
      - id: backport
        name: Open Backport Pull Request
        uses: quipper/monorepo-deploy-actions/open-backport-pull-request@v1
        with:
          base-branch: ${{ env.BACKPORT_BASE_BRANCH }}
      - name: Notify to Slack
        if: ${{ startsWith(steps.open-pull-request.outputs.pull-request-url, 'https://') }}
        uses: Ilshidur/action-slack@2.1.0
        env:
          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
        with:
          args: |
            Backport ${{ steps.backport.outputs.head-branch }} into ${{ steps.backport.outputs.base-branch }}:
            ${{ steps.backport.outputs.pull-request-url }}
```