### PR TITLE
Fix fixture branch of e2e to ephemeral

### DIFF
--- a/.github/workflows/git-delete-namespace-application.yaml
+++ b/.github/workflows/git-delete-namespace-application.yaml
@@ -39,6 +39,8 @@ jobs:
       - run: yarn package
 
       - run: bash e2e-test-setup.sh
+        env:
+          BRANCH_NAME: e2e/git-delete-namespace-application/${{ github.run_number }}
       - uses: ./git-delete-namespace-application
         id: retain
         with:
@@ -48,10 +50,10 @@ jobs:
           overlay: staging
           namespace-prefix: pr-
           destination-repository: ${{ github.repository }}
-          destination-branch: e2e-test-fixture-${{ github.run_id }}
+          destination-branch: e2e/git-delete-namespace-application/${{ github.run_number }}
       - run: test "${{ steps.retain.outputs.deleted-pull-request-numbers }}" -eq 101
       - name: Clean up the branch
         continue-on-error: true
         if: always()
         run: |
-          git push origin --delete refs/heads/e2e-test-fixture-${{ github.run_id }}
+          git push origin --delete refs/heads/e2e/git-delete-namespace-application/${{ github.run_number }}

--- a/.github/workflows/git-push-namespace.yaml
+++ b/.github/workflows/git-push-namespace.yaml
@@ -42,18 +42,18 @@ jobs:
 
       - run: ${{ github.workspace }}/.github/e2e-test-config.sh
         id: config
-      - run: git push origin HEAD:refs/heads/e2e-test-fixture/${{ steps.config.outputs.namespace }}
+      - run: git push origin HEAD:refs/heads/e2e/git-push-namespace/${{ github.run_number }}
 
       - uses: ./git-push-namespace
         with:
           overlay: ${{ steps.config.outputs.overlay }}
           namespace: ${{ steps.config.outputs.namespace }}
           destination-repository: ${{ github.repository }}
-          destination-branch: e2e-test-fixture/${{ steps.config.outputs.namespace }}
+          destination-branch: e2e/git-push-namespace/${{ github.run_number }}
 
       - uses: actions/checkout@v2
         with:
-          ref: e2e-test-fixture/${{ steps.config.outputs.namespace }}
+          ref: e2e/git-push-namespace/${{ github.run_number }}
           path: git-push-namespace/actual
       - run: find actual -type f
       - run: test -f actual/monorepo-deploy-actions/${{ steps.config.outputs.overlay }}/${{ steps.config.outputs.namespace }}.yaml
@@ -61,4 +61,4 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          git push origin --delete refs/heads/e2e-test-fixture/${{ steps.config.outputs.namespace }}
+          git push origin --delete refs/heads/e2e/git-push-namespace/${{ github.run_number }}

--- a/git-delete-namespace-application/e2e-test-setup.sh
+++ b/git-delete-namespace-application/e2e-test-setup.sh
@@ -14,4 +14,4 @@ git add .
 git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 git config user.name 'github-actions[bot]'
 git commit -m "e2e-test-fixture for ${GITHUB_REF}"
-git push origin "HEAD:refs/heads/e2e-test-fixture-${GITHUB_RUN_ID}"
+git push origin "HEAD:refs/heads/${BRANCH_NAME}"


### PR DESCRIPTION
This will fix the tests eventually fail, e.g., https://github.com/quipper/monorepo-deploy-actions/runs/3551517140?check_suite_focus=true:

```
 ! [remote rejected] HEAD -> e2e-test-fixture/refs-pull-69-merge (shallow update not allowed)
```