### PR TITLE
Remove link to PR in commit message

### DIFF
--- a/git-push-namespace/src/run.ts
+++ b/git-push-namespace/src/run.ts
@@ -60,7 +60,6 @@ const push = async (inputs: Inputs): Promise<boolean> => {
 
 const commitMessageFooter = [
   'git-push-namespace',
-  github.context.payload.pull_request?.html_url ?? '',
   `${github.context.payload.repository?.html_url ?? ''}/commit/${github.context.sha}`,
   `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`,
 ].join('\n')

--- a/git-push-service/src/run.ts
+++ b/git-push-service/src/run.ts
@@ -106,7 +106,6 @@ const commitMessage = (namespace: string, services: string[]) => {
 
 const commitMessageFooter = [
   'git-push-service',
-  github.context.payload.pull_request?.html_url ?? '',
   `${github.context.payload.repository?.html_url ?? ''}/commit/${github.context.sha}`,
   `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`,
 ].join('\n')

--- a/git-push-services-from-prebuilt/src/run.ts
+++ b/git-push-services-from-prebuilt/src/run.ts
@@ -74,7 +74,6 @@ const commitMessage = (namespace: string) => {
 
 const commitMessageFooter = [
   'git-push-services-from-prebuilt',
-  github.context.payload.pull_request?.html_url ?? '',
   `${github.context.payload.repository?.html_url ?? ''}/commit/${github.context.sha}`,
   `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`,
 ].join('\n')


### PR DESCRIPTION
Recently GitHub changed to show a link in a commit message, like https://github.com/quipper/monorepo-deploy-actions/pull/199#ref-commit-29b667a:

![image](https://user-images.githubusercontent.com/321266/142340336-588bfdde-f309-423d-bc8e-11f1bdba6449.png)

It is very noisy if many services are deploying.
