### PR TITLE
Don't overwrite service by prebuilt manifest

### DIFF
--- a/git-push-services-from-prebuilt/README.md
+++ b/git-push-services-from-prebuilt/README.md
@@ -61,3 +61,18 @@ It generates an `Application` manifest with the following properties:
   - path: `services/${service}`
 - destination
   - namespace: `${namespace}`
+
+
+## Caveat
+
+`git-push-service` and `git-push-services-from-prebuilt` may run concurrently.
+If an application manifest of a service already exists, this action does not overwrite the service.
+
+Both actions should perform the deploy as follows:
+
+1. When a pull request is created,
+    - `git-push-services-from-prebuilt` pushes the prebuilt manifest
+    - `git-push-service` overwrites the manifest
+1. When the pull request is synchronized,
+    - `git-push-services-from-prebuilt` does nothing
+    - `git-push-service` overwrites the manifest

--- a/git-push-services-from-prebuilt/tests/arrange.test.ts
+++ b/git-push-services-from-prebuilt/tests/arrange.test.ts
@@ -28,22 +28,11 @@ test('if workspace is empty', async () => {
   )
 })
 
-test('if workspace has a service with different sha', async () => {
+test('if service A is already pushed', async () => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-from-prebuilt-'))
 
-  // put a service which is pushed by the job of old sha
   await fs.mkdir(path.join(workspace, `applications`))
-  await fs.writeFile(
-    path.join(workspace, `applications/namespace--a.yaml`),
-    `\
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  annotations:
-    github.ref: refs/heads/main
-    github.sha: another_sha
-`
-  )
+  await fs.writeFile(path.join(workspace, `applications/namespace--a.yaml`), 'dummy-generated-application')
   await fs.mkdir(path.join(workspace, `services`))
   await fs.mkdir(path.join(workspace, `services/a`))
   await fs.writeFile(path.join(workspace, `services/a/generated.yaml`), 'dummy-generated-manifest')
@@ -58,42 +47,12 @@ metadata:
     destinationRepository: 'octocat/manifests',
   })
 
-  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe(applicationA)
-  expect(await readContent(path.join(workspace, `services/a/generated.yaml`))).toBe(
-    await readContent(path.join(__dirname, `fixtures/prebuilt/services/a/generated.yaml`))
-  )
-})
-
-test('if workspace has a service with current sha', async () => {
-  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-from-prebuilt-'))
-
-  // put a service which is pushed by the job of old sha
-  await fs.mkdir(path.join(workspace, `applications`))
-  const dummyApplication = `\
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  annotations:
-    github.ref: refs/heads/main
-    github.sha: current_sha
-`
-  await fs.writeFile(path.join(workspace, `applications/namespace--a.yaml`), dummyApplication)
-  await fs.mkdir(path.join(workspace, `services`))
-  await fs.mkdir(path.join(workspace, `services/a`))
-  await fs.writeFile(path.join(workspace, `services/a/generated.yaml`), 'dummy-generated-manifest')
-
-  await arrangeManifests({
-    workspace,
-    branch: `ns/project/overlay/namespace`,
-    namespace: 'namespace',
-    project: 'project',
-    context: { sha: 'current_sha', ref: 'refs/heads/main' },
-    prebuiltDirectory: path.join(__dirname, `fixtures/prebuilt`),
-    destinationRepository: 'octocat/manifests',
-  })
-
-  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe(dummyApplication)
+  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe('dummy-generated-application')
   expect(await readContent(path.join(workspace, `services/a/generated.yaml`))).toBe('dummy-generated-manifest')
+  expect(await readContent(path.join(workspace, `applications/namespace--b.yaml`))).toBe(applicationB)
+  expect(await readContent(path.join(workspace, `services/b/generated.yaml`))).toBe(
+    await readContent(path.join(__dirname, `fixtures/prebuilt/services/b/generated.yaml`))
+  )
 })
 
 const applicationA = `\


### PR DESCRIPTION
## Problem to solve
When a pull request is updated (synchronized), the default branch is deployed and then the change is deployed. It often confuses developers.

This is because of the current behavior like:

1. When a pull request is created,
    - `git-push-services-from-prebuilt` pushes the prebuilt manifest
    - `git-push-service` overwrites the manifest
1. When the pull request is synchronized,
    - `git-push-services-from-prebuilt` **overwrites** the manifest to the prebuilt one
    - `git-push-service` overwrites the manifest

## Solution
This PR will change the behavior as follows:

1. When a pull request is created,
    - `git-push-services-from-prebuilt` pushes the prebuilt manifest
    - `git-push-service` overwrites the manifest
1. When the pull request is synchronized,
    - `git-push-services-from-prebuilt` **does nothing**
    - `git-push-service` overwrites the manifest
