### PR TITLE
Fix prebuilt manifest is not updated to the latest when PR is updated

### DIFF
--- a/git-push-services-from-prebuilt/README.md
+++ b/git-push-services-from-prebuilt/README.md
@@ -66,13 +66,20 @@ It generates an `Application` manifest with the following properties:
 ## Caveat
 
 `git-push-service` and `git-push-services-from-prebuilt` may run concurrently.
-If an application manifest of a service already exists, this action does not overwrite the service.
+If an application manifest was pushed by `git-push-service`, this action does not overwrite it.
 
-Both actions should perform the deploy as follows:
+**Case 1**: If a service is not changed in a pull request,
+
+1. When a pull request is created,
+    - `git-push-services-from-prebuilt` pushes the prebuilt manifest
+1. When the pull request is synchronized,
+    - `git-push-services-from-prebuilt` overwrites the manifest.
+      This is needed to follow the latest prebuilt manifest
+
+**Case 2**: If a service is changed in a pull request,
 
 1. When a pull request is created,
     - `git-push-services-from-prebuilt` pushes the prebuilt manifest
     - `git-push-service` overwrites the manifest
 1. When the pull request is synchronized,
-    - `git-push-services-from-prebuilt` does nothing
-    - `git-push-service` overwrites the manifest
+    - `git-push-services-from-prebuilt` don't overwrite it

--- a/git-push-services-from-prebuilt/tests/arrange.test.ts
+++ b/git-push-services-from-prebuilt/tests/arrange.test.ts
@@ -5,7 +5,7 @@ import { arrangeManifests } from '../src/arrange'
 
 const readContent = async (f: string) => (await fs.readFile(f)).toString()
 
-test('if workspace is empty', async () => {
+test('if workspace is empty, just create', async () => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-from-prebuilt-'))
 
   await arrangeManifests({
@@ -28,11 +28,11 @@ test('if workspace is empty', async () => {
   )
 })
 
-test('if service A is already pushed', async () => {
+test('if service was pushed by git-push-services-from-prebuilt, overwrite it', async () => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-from-prebuilt-'))
 
   await fs.mkdir(path.join(workspace, `applications`))
-  await fs.writeFile(path.join(workspace, `applications/namespace--a.yaml`), 'dummy-generated-application')
+  await fs.writeFile(path.join(workspace, `applications/namespace--a.yaml`), applicationA)
   await fs.mkdir(path.join(workspace, `services`))
   await fs.mkdir(path.join(workspace, `services/a`))
   await fs.writeFile(path.join(workspace, `services/a/generated.yaml`), 'dummy-generated-manifest')
@@ -47,12 +47,35 @@ test('if service A is already pushed', async () => {
     destinationRepository: 'octocat/manifests',
   })
 
-  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe('dummy-generated-application')
-  expect(await readContent(path.join(workspace, `services/a/generated.yaml`))).toBe('dummy-generated-manifest')
-  expect(await readContent(path.join(workspace, `applications/namespace--b.yaml`))).toBe(applicationB)
-  expect(await readContent(path.join(workspace, `services/b/generated.yaml`))).toBe(
-    await readContent(path.join(__dirname, `fixtures/prebuilt/services/b/generated.yaml`))
+  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe(applicationA)
+  expect(await readContent(path.join(workspace, `services/a/generated.yaml`))).toBe(
+    await readContent(path.join(__dirname, `fixtures/prebuilt/services/a/generated.yaml`))
   )
+})
+
+test('if service was pushed by git-push-service, do not overwrite it', async () => {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-from-prebuilt-'))
+
+  await fs.mkdir(path.join(workspace, `applications`))
+  await fs.writeFile(path.join(workspace, `applications/namespace--a.yaml`), applicationPushedByGitPushService)
+  await fs.mkdir(path.join(workspace, `services`))
+  await fs.mkdir(path.join(workspace, `services/a`))
+  await fs.writeFile(path.join(workspace, `services/a/generated.yaml`), 'dummy-generated-manifest')
+
+  await arrangeManifests({
+    workspace,
+    branch: `ns/project/overlay/namespace`,
+    namespace: 'namespace',
+    project: 'project',
+    context: { sha: 'current_sha', ref: 'refs/heads/main' },
+    prebuiltDirectory: path.join(__dirname, `fixtures/prebuilt`),
+    destinationRepository: 'octocat/manifests',
+  })
+
+  expect(await readContent(path.join(workspace, `applications/namespace--a.yaml`))).toBe(
+    applicationPushedByGitPushService
+  )
+  expect(await readContent(path.join(workspace, `services/a/generated.yaml`))).toBe('dummy-generated-manifest')
 })
 
 const applicationA = `\
@@ -64,9 +87,31 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    github.ref: refs/heads/main
-    github.sha: current_sha
     github.action: git-push-services-from-prebuilt
+spec:
+  project: project
+  source:
+    repoURL: https://github.com/octocat/manifests.git
+    targetRevision: ns/project/overlay/namespace
+    path: services/a
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: namespace
+  syncPolicy:
+    automated:
+      prune: true
+`
+
+const applicationPushedByGitPushService = `\
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: namespace--a
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    github.action: git-push-service
 spec:
   project: project
   source:
@@ -90,8 +135,6 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    github.ref: refs/heads/main
-    github.sha: current_sha
     github.action: git-push-services-from-prebuilt
 spec:
   project: project


### PR DESCRIPTION
Follow up https://github.com/quipper/monorepo-deploy-actions/pull/295.

## Problem to solve
When a pull request is created and then updated without a change of service, the service will be old. This is because `git-push-services-from-prebuilt` pushes a manifest only first time.

1. When a pull request is created,
    - `git-push-services-from-prebuilt` pushes the prebuilt manifest
1. When the pull request is synchronized,
    - `git-push-services-from-prebuilt` **don't** overwrite it

We expect a service is updated when a pull request is updated.

## Solution
Change the behavior as follows:

1. When the pull request is synchronized,
    - `git-push-services-from-prebuilt` overwrites it if it was pushed by `git-push-services-from-prebuilt`
    - `git-push-services-from-prebuilt` don't overwrite it if it was pushed by `git-push-service`
