### PR TITLE
Fix command of ref deletion

### DIFF
--- a/.github/workflows/git-push-service.yaml
+++ b/.github/workflows/git-push-service.yaml
@@ -54,6 +54,7 @@ jobs:
           namespace: ${{ steps.config.outputs.namespace }}
           namespace-level: true
           destination-repository: ${{ github.repository }}
+          via-pull-request: true
 
       - uses: actions/checkout@v3
         with:

--- a/git-push-service/src/git.ts
+++ b/git-push-service/src/git.ts
@@ -59,4 +59,4 @@ export const pushByFastForward = async (cwd: string, branch: string): Promise<nu
 }
 
 export const deleteRef = async (cwd: string, ref: string): Promise<number> =>
-  await exec.exec('git', ['push', '--delete', ref], { cwd, ignoreReturnCode: true })
+  await exec.exec('git', ['push', '--delete', 'origin', ref], { cwd, ignoreReturnCode: true })


### PR DESCRIPTION
This will fix `git push --delete` command.

Currently the following error occurs:

```console
/usr/bin/git push --delete git-push-service--namespace--service--1653472366989
fatal: --delete doesn't make sense without any refs
```