### PR TITLE
Don't push application if no manifest is given

### DIFF
--- a/git-push-service/README.md
+++ b/git-push-service/README.md
@@ -18,6 +18,8 @@ Name | Type | Description
 `update-via-pull-request` | boolean | Update a branch via a pull request (default to false)
 `token` | string | GitHub token (default to `github.token`)
 
+If `manifests` do not match anything, this action does nothing.
+
 
 ## Outputs
 

--- a/git-push-service/src/run.ts
+++ b/git-push-service/src/run.ts
@@ -34,6 +34,10 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
 
   const globber = await glob.create(inputs.manifests, { matchDirectories: false })
   const manifests = await globber.glob()
+  core.info(`found ${manifests.length} manifest(s) in ${inputs.manifests}`)
+  if (manifests.length === 0) {
+    return {}
+  }
 
   if (!inputs.updateViaPullRequest) {
     // retry when fast-forward is failed


### PR DESCRIPTION
## Problem to solve
If `manifests` do not match anything, this action creates only application without a manifest. It causes "unknown" state in Argo CD.

<img width="358" alt="image" src="https://user-images.githubusercontent.com/321266/177667035-adcf1192-9998-400e-ba75-a9488ef46739.png">

## How to solve
Do nothing if no manifest is given.