### PR TITLE
refactor: use exec.getExecOutput()

### DIFF
--- a/git-delete-namespace-application/src/git.ts
+++ b/git-delete-namespace-application/src/git.ts
@@ -40,7 +40,7 @@ export const checkout = async (cwd: string, branch: string): Promise<void> => {
 
 export const status = async (cwd: string): Promise<string> => {
   const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
-  return output.stdout
+  return output.stdout.trim()
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-delete-namespace-application/src/git.ts
+++ b/git-delete-namespace-application/src/git.ts
@@ -39,9 +39,8 @@ export const checkout = async (cwd: string, branch: string): Promise<void> => {
 }
 
 export const status = async (cwd: string): Promise<string> => {
-  const chunks: Buffer[] = []
-  await exec.exec('git', ['status', '--porcelain'], { cwd, listeners: { stdout: (b) => chunks.push(b) } })
-  return Buffer.concat(chunks).toString().trim()
+  const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
+  return output.stdout
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-namespace/src/git.ts
+++ b/git-push-namespace/src/git.ts
@@ -40,7 +40,7 @@ export const checkout = async (cwd: string, branch: string): Promise<void> => {
 
 export const status = async (cwd: string): Promise<string> => {
   const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
-  return output.stdout
+  return output.stdout.trim()
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-namespace/src/git.ts
+++ b/git-push-namespace/src/git.ts
@@ -39,9 +39,8 @@ export const checkout = async (cwd: string, branch: string): Promise<void> => {
 }
 
 export const status = async (cwd: string): Promise<string> => {
-  const chunks: Buffer[] = []
-  await exec.exec('git', ['status', '--porcelain'], { cwd, listeners: { stdout: (b) => chunks.push(b) } })
-  return Buffer.concat(chunks).toString().trim()
+  const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
+  return output.stdout
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-service/src/git.ts
+++ b/git-push-service/src/git.ts
@@ -42,9 +42,8 @@ export const checkoutIfExist = async (cwd: string, branch: string): Promise<numb
 }
 
 export const status = async (cwd: string): Promise<string> => {
-  const chunks: Buffer[] = []
-  await exec.exec('git', ['status', '--porcelain'], { cwd, listeners: { stdout: (b) => chunks.push(b) } })
-  return Buffer.concat(chunks).toString().trim()
+  const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
+  return output.stdout
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-service/src/git.ts
+++ b/git-push-service/src/git.ts
@@ -43,7 +43,7 @@ export const checkoutIfExist = async (cwd: string, branch: string): Promise<numb
 
 export const status = async (cwd: string): Promise<string> => {
   const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
-  return output.stdout
+  return output.stdout.trim()
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-services-from-prebuilt/src/git.ts
+++ b/git-push-services-from-prebuilt/src/git.ts
@@ -42,9 +42,8 @@ export const checkoutIfExist = async (cwd: string, branch: string): Promise<numb
 }
 
 export const status = async (cwd: string): Promise<string> => {
-  const chunks: Buffer[] = []
-  await exec.exec('git', ['status', '--porcelain'], { cwd, listeners: { stdout: (b) => chunks.push(b) } })
-  return Buffer.concat(chunks).toString().trim()
+  const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
+  return output.stdout
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {

--- a/git-push-services-from-prebuilt/src/git.ts
+++ b/git-push-services-from-prebuilt/src/git.ts
@@ -43,7 +43,7 @@ export const checkoutIfExist = async (cwd: string, branch: string): Promise<numb
 
 export const status = async (cwd: string): Promise<string> => {
   const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
-  return output.stdout
+  return output.stdout.trim()
 }
 
 export const commit = async (cwd: string, message: string): Promise<void> => {


### PR DESCRIPTION
`getExecOutput()` is available since @actions/exec 1.1.0
https://github.com/actions/toolkit/blob/main/packages/exec/RELEASES.md#110