### PR TITLE
Check if namespace branch exists (git-push-namespace)

### DIFF
--- a/.github/workflows/git-push-namespace.yaml
+++ b/.github/workflows/git-push-namespace.yaml
@@ -40,9 +40,12 @@ jobs:
         with:
           ref: ${{ github.head_ref }} # avoid "shallow update not allowed" error
           path: e2e-test-fixture
-      - name: Set up a fixture branch
+      - name: Set up a fixture of overlay branch
         working-directory: e2e-test-fixture
         run: git push origin "HEAD:refs/heads/e2e-git-push-namespace-${{ github.run_number }}"
+      - name: Set up a fixture of namespace branch
+        working-directory: e2e-test-fixture
+        run: git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/e2e-git-push-namespace/ns-${{ github.run_number }}"
 
       - uses: ./git-push-namespace
         with:
@@ -58,8 +61,13 @@ jobs:
       - run: find actual -type f
       - run: test -f actual/monorepo-deploy-actions/e2e-git-push-namespace/ns-${{ github.run_number }}.yaml
 
-      - name: Clean up the branch
+      - name: Clean up the overlay branch
         continue-on-error: true
         if: always()
         run: |
           git push origin --delete "refs/heads/e2e-git-push-namespace-${{ github.run_number }}"
+      - name: Clean up the namespace branch
+        continue-on-error: true
+        if: always()
+        run: |
+          git push origin --delete "refs/heads/ns/monorepo-deploy-actions/e2e-git-push-namespace/ns-${{ github.run_number }}"

--- a/git-push-namespace/README.md
+++ b/git-push-namespace/README.md
@@ -16,7 +16,7 @@ Name | Type | Description
 
 ## Getting Started
 
-To add a namespace:
+To push a namespace manifest:
 
 ```yaml
     steps:
@@ -26,4 +26,28 @@ To add a namespace:
           namespace: pr-12345
 ```
 
-This action writes an `Application` to `${project}/${overlay}/${namespace}.yaml` in the destination repository.
+It writes the following `Application` to `${project}/${overlay}/${namespace}.yaml` in the destination repository.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${namespace}
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: project
+  source:
+    repoURL: https://github.com/octocat/manifests.git
+    targetRevision: ns/${project}/${overlay}/${namespace}
+    path: applications
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+```
+
+If the namespace branch `ns/${project}/${overlay}/${namespace}` does not exist, this action throws an error.

--- a/git-push-namespace/src/run.ts
+++ b/git-push-namespace/src/run.ts
@@ -15,11 +15,26 @@ interface Inputs {
   token: string
 }
 
-export const run = async (inputs: Inputs): Promise<void> =>
+export const run = async (inputs: Inputs): Promise<void> => {
+  await checkIfNamespaceBranchExists(inputs)
   await retry(async () => push(inputs), {
     maxAttempts: 5,
     waitMillisecond: 10000,
   })
+}
+
+const checkIfNamespaceBranchExists = async (inputs: Inputs): Promise<void> => {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-namespace-action-'))
+  core.info(`created workspace at ${workspace}`)
+
+  const project = github.context.repo.repo
+  const namespaceBranch = `ns/${project}/${inputs.overlay}/${inputs.namespace}`
+
+  core.startGroup(`checking if namespace branch ${namespaceBranch} exists`)
+  await git.init(workspace, inputs.destinationRepository, inputs.token)
+  await git.checkout(workspace, namespaceBranch)
+  core.endGroup()
+}
 
 const push = async (inputs: Inputs): Promise<void | Error> => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-namespace-action-'))

--- a/git-push-namespace/src/run.ts
+++ b/git-push-namespace/src/run.ts
@@ -17,7 +17,7 @@ interface Inputs {
 
 export const run = async (inputs: Inputs): Promise<void> => {
   await checkIfNamespaceBranchExists(inputs)
-  await retry(async () => push(inputs), {
+  await retry(() => pushNamespaceApplication(inputs), {
     maxAttempts: 5,
     waitMillisecond: 10000,
   })
@@ -36,7 +36,7 @@ const checkIfNamespaceBranchExists = async (inputs: Inputs): Promise<void> => {
   core.endGroup()
 }
 
-const push = async (inputs: Inputs): Promise<void | Error> => {
+const pushNamespaceApplication = async (inputs: Inputs): Promise<void | Error> => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-namespace-action-'))
   core.info(`created workspace at ${workspace}`)
 


### PR DESCRIPTION
## Problem to solve
This action pushes an Application manifest even if the corresponding namespace branch does not exist.
It would be nice to check if the namespace branch exists.
