### PR TITLE
Replace `prebuilt` option with `destination-branch` option

### DIFF
--- a/git-push-service/README.md
+++ b/git-push-service/README.md
@@ -14,7 +14,7 @@ Name | Type | Description
 `namespace-level` | boolean | Push the manifests to namespace level (default to false)
 `application-annotations` | multiline string | Annotations to add to an Application (default to empty)
 `destination-repository` | string | Destination repository
-`prebuilt` | boolean | Push prebuilt manifest (default to false)
+`destination-branch` | string | Destination branch (default to `ns/${project}/${overlay}/${namespace}`)
 `update-via-pull-request` | boolean | Update a branch via a pull request (default to false)
 `token` | string | GitHub token (default to `github.token`)
 
@@ -115,13 +115,13 @@ To push a manifest as a prebuilt manifest:
           manifests: ${{ steps.kustomize.outputs.directory }}/**
           overlay: pr
           service: foo
-          prebuilt: true
+          destination-branch: prebuilt/REPOSITORY/pr
 ```
 
 It pushes the following file into a destination repository:
 
 ```
-destination-repository (branch: prebuilt/${project}/${overlay}/${ref})
+destination-repository (branch: prebuilt/${project}/${overlay})
 └── services
     └── ${service}
         └── generated.yaml

--- a/git-push-service/action.yaml
+++ b/git-push-service/action.yaml
@@ -24,10 +24,14 @@ inputs:
   destination-repository:
     description: destination repository
     required: true
+  destination-branch:
+    description: destination branch (default to ns/REPOSITORY/OVERLAY/NAMESPACE)
+    required: false
   prebuilt:
     description: push prebuilt manifest
     required: true
     default: 'false'
+    deprecationMessage: use destination-branch instead # TODO: deprecated
   update-via-pull-request:
     description: update a branch via a pull request
     required: true

--- a/git-push-service/src/main.ts
+++ b/git-push-service/src/main.ts
@@ -10,7 +10,8 @@ async function main(): Promise<void> {
     namespaceLevel: core.getBooleanInput('namespace-level', { required: true }),
     applicationAnnotations: core.getMultilineInput('application-annotations'),
     destinationRepository: core.getInput('destination-repository', { required: true }),
-    prebuilt: core.getBooleanInput('prebuilt', { required: true }),
+    destinationBranch: core.getInput('destination-branch'),
+    prebuilt: core.getBooleanInput('prebuilt', { required: true }), // TODO: deprecated
     updateViaPullRequest: core.getBooleanInput('update-via-pull-request', { required: true }),
     token: core.getInput('token', { required: true }),
   })

--- a/git-push-service/src/run.ts
+++ b/git-push-service/src/run.ts
@@ -17,7 +17,8 @@ type Inputs = {
   namespaceLevel: boolean
   applicationAnnotations: string[]
   destinationRepository: string
-  prebuilt: boolean
+  destinationBranch: string
+  prebuilt: boolean // TODO: deprecated
   updateViaPullRequest: boolean
   token: string
 }
@@ -63,9 +64,12 @@ const push = async (manifests: string[], inputs: Inputs): Promise<Outputs | Erro
 
   const [owner, repo] = inputs.destinationRepository.split('/')
   const project = github.context.repo.repo
-  const branch = inputs.prebuilt
-    ? `prebuilt/${project}/${inputs.overlay}/${github.context.ref}`
+  let branch = inputs.prebuilt
+    ? `prebuilt/${project}/${inputs.overlay}/${github.context.ref}` // TODO: deprecated
     : `ns/${project}/${inputs.overlay}/${inputs.namespace}`
+  if (inputs.destinationBranch) {
+    branch = inputs.destinationBranch
+  }
 
   core.startGroup(`checkout branch ${branch} if exist`)
   await git.init(workspace, owner, repo, inputs.token)

--- a/git-push-services-from-prebuilt/README.md
+++ b/git-push-services-from-prebuilt/README.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: prebuilt/REPOSITORY/pr/refs/heads/main
+          ref: prebuilt/REPOSITORY/pr
           path: prebuilt
       - uses: quipper/monorepo-deploy-actions/substitute@v1
         with:


### PR DESCRIPTION
## Problem to solve
Currently, the prebuilt branch name is hardcoded in git-push-service action. It would be nice to set a custom name.
