### PR TITLE
Allow auto merge for AWS SDK packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,12 @@
         "@types/node",
       ],
     },
+    {
+      "automerge": true,
+      "reviewers": [],
+      "matchPackagePrefixes": ["@aws-sdk/"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+    },
   ],
   "reviewers": [
     "team:sre",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
     "config:base",
     "github>int128/typescript-action-renovate-config",
   ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchPaths": ["*/**"],


### PR DESCRIPTION
I think we can allow auto merge for minor upgrades.

Seeing the changelog, it rarely does breaking changes:
https://github.com/aws/aws-sdk-js-v3/blob/main/CHANGELOG.md