### PR TITLE
Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,6 @@
 {
+  // Note:
+  // DO NOT enable platformAutomerge, because this repository does not have a required check in the branch protection rules.
   "extends": [
     "config:base",
     "github>int128/typescript-action-renovate-config#v1.0.0",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,14 @@
 {
   "extends": [
     "config:base",
-    "github>int128/typescript-action-renovate-config",
+    "github>int128/typescript-action-renovate-config#v1.0.0",
+    ":automergeMinor",
+    ":label(renovate/{{depName}})",
+    ":reviewer(team:sre)",
   ],
   "packageRules": [
     {
+      "description": "Split pull requests by action",
       "matchPaths": ["*/**"],
       "additionalBranchPrefix": "{{packageFileDir}}-",
       "commitMessageSuffix": "({{packageFileDir}})",
@@ -13,8 +17,5 @@
         "@types/node",
       ],
     },
-  ],
-  "reviewers": [
-    "team:sre",
   ],
 }


### PR DESCRIPTION
Fix https://github.com/quipper/monorepo-deploy-actions/pull/867.

https://github.com/int128/typescript-action-renovate-config/pull/15 breaks the automerge config.
I tagged the current config as v1.0.0 and use it in this repository.
