### PR TITLE
Update int128/typescript-action-renovate-config to v1.1.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   // DO NOT enable platformAutomerge, because this repository does not have a required check in the branch protection rules.
   "extends": [
     "config:base",
-    "github>int128/typescript-action-renovate-config#v1.0.0",
+    "github>int128/typescript-action-renovate-config#v1.1.0",
     ":automergeMinor",
     ":label(renovate/{{depName}})",
     ":reviewer(team:sre)",


### PR DESCRIPTION
I noticed package.json is not pinned.
I'd like to update the Renovate config to https://github.com/int128/typescript-action-renovate-config/releases/tag/v1.1.0