### PR TITLE
Auto-fix lint and format

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -1,0 +1,27 @@
+name: autofix
+
+on:
+  pull_request:
+    paths:
+      - '**/*.ts'
+      - '*.json'
+      - .github/workflows/autofix.yaml
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn
+      - run: yarn workspaces run lint --fix
+      - uses: int128/update-generated-files-action@v2
+
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn
+      - run: yarn workspaces run format
+      - uses: int128/update-generated-files-action@v2


### PR DESCRIPTION
It would be nice if the changes of eslint and prettier are automatically updated.
e.g., https://github.com/quipper/monorepo-deploy-actions/pull/1027