### PR TITLE
Add empty commit to backport PR

### DIFF
--- a/open-backport-pull-request/src/run.ts
+++ b/open-backport-pull-request/src/run.ts
@@ -60,7 +60,7 @@ type openPullRequestParams = {
   octokit: Octokit
 }
 
-const openPullRequest = async (params: openPullRequestParams): Promise<string | undefined> => {
+const openPullRequest = async (params: openPullRequestParams): Promise<string> => {
   const commitMessage = `Backport from ${params.headBranch} into ${params.baseBranch}
 
 Created by GitHub Actions


### PR DESCRIPTION
## Problem to solve
We cannot merge a pull request if the following case:

- The status of head branch is failing.
- Base branch has a branch protection rule with a required check.

For example,

```mermaid
gitGraph
    commit id:"a"
    branch production
    commit id:"b"
    checkout main
    commit id:"c"
    checkout production
    merge main id:"Deploy"
    checkout main
    merge production id:"Backport"
```

if the status of `Deploy` is failing, we cannot merge the `Backport` pull request.

## How to solve
Add an empty commit to the head commit before creating a pull request.
