### PR TITLE
Fix package rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   packageRules: [
     {
       description: 'Split pull requests by action',
-      matchPaths: ['*/**'],
+      matchFileNames: ['*/**'],
       additionalBranchPrefix: '{{packageFileDir}}-',
       commitMessageSuffix: '({{packageFileDir}})',
       excludePackageNames: [


### PR DESCRIPTION
## Problem to solve

- I want to change to use `matchFileNames` since `matchPaths` has been removed
  - > matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed
  - https://docs.renovatebot.com/release-notes-for-major-versions/