### PR TITLE
Add draft option and fix summary

### DIFF
--- a/create-deploy-pull-request/README.md
+++ b/create-deploy-pull-request/README.md
@@ -61,6 +61,7 @@ jobs:
 | `title`       | (required)     | Title of pull request             |
 | `body`        | (required)     | Body of pull request              |
 | `labels`      | -              | Label of pull request (multiline) |
+| `draft`       | `true`         | Set the pull request to draft     |
 | `token`       | `github.token` | GitHub token                      |
 
 ### Outputs

--- a/create-deploy-pull-request/action.yaml
+++ b/create-deploy-pull-request/action.yaml
@@ -17,6 +17,10 @@ inputs:
   labels:
     description: Label of pull request (multiline)
     required: false
+  draft:
+    description: Set the pull request to draft
+    required: true
+    default: 'true'
   token:
     description: GitHub token
     required: true

--- a/create-deploy-pull-request/src/main.ts
+++ b/create-deploy-pull-request/src/main.ts
@@ -9,11 +9,13 @@ const main = async (): Promise<void> => {
     title: core.getInput('title', { required: true }),
     body: core.getInput('body', { required: true }),
     labels: core.getMultilineInput('labels'),
+    draft: core.getBooleanInput('draft', { required: true }),
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     actor: github.context.actor,
     token: core.getInput('token', { required: true }),
   })
+  await core.summary.write()
 }
 
 main().catch((e: Error) => {

--- a/create-deploy-pull-request/src/pull.ts
+++ b/create-deploy-pull-request/src/pull.ts
@@ -10,6 +10,7 @@ type CreatePullOptions = {
   base: string
   title: string
   body: string
+  draft: boolean
   labels: string[]
   reviewers: string[]
   assignees: string[]
@@ -38,6 +39,7 @@ export const createPull = async (octokit: Octokit, options: CreatePullOptions) =
     head: options.head,
     title: options.title,
     body: options.body,
+    draft: options.draft,
   })
   core.info(`Created ${pull.html_url}`)
   core.summary.addRaw(`Created [#${pull.number} ${pull.title}](${pull.html_url})`, true)

--- a/create-deploy-pull-request/src/run.ts
+++ b/create-deploy-pull-request/src/run.ts
@@ -8,6 +8,7 @@ type Inputs = {
   base: string
   title: string
   body: string
+  draft: boolean
   labels: string[]
   owner: string
   repo: string
@@ -44,6 +45,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
     base: inputs.base,
     title: inputs.title,
     body: inputs.body,
+    draft: inputs.draft,
     labels: inputs.labels,
     reviewers: [inputs.actor],
     assignees: [inputs.actor],

--- a/create-deploy-pull-request/tests/run.test.ts
+++ b/create-deploy-pull-request/tests/run.test.ts
@@ -42,6 +42,7 @@ it('should create base branch if not exist', async () => {
     body: 'Hello',
     actor: 'octocat',
     labels: [],
+    draft: true,
     owner: 'OWNER',
     repo: 'REPO',
     token: 'GITHUB_TOKEN',
@@ -84,6 +85,7 @@ it('should create pull request if base branch exists', async () => {
     body: 'Hello',
     actor: 'octocat',
     labels: [],
+    draft: true,
     owner: 'OWNER',
     repo: 'REPO',
     token: 'GITHUB_TOKEN',
@@ -102,5 +104,6 @@ it('should create pull request if base branch exists', async () => {
     base: 'production',
     title: 'Deploy service to production',
     body: 'Hello',
+    draft: true,
   })
 })


### PR DESCRIPTION
## Changes
### Add draft option
It would be nice if we can change the pull request from draft when ready to deploy.

### Fix summary
I noticed that no summary is shown in a workflow.

It should be like https://github.com/quipper/monorepo-deploy-actions/actions/runs/6093344863,

<img width="1241" alt="image" src="https://github.com/quipper/monorepo-deploy-actions/assets/321266/c16cc5b7-b84e-405c-b54f-f32409f89860">
