### PR TITLE
Fix git rev-parse error

### DIFF
--- a/delete-pull-request-namespaces/src/git.ts
+++ b/delete-pull-request-namespaces/src/git.ts
@@ -68,7 +68,7 @@ export const commit = async (cwd: string, message: string): Promise<void> => {
   await exec.exec('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { cwd })
   await exec.exec('git', ['config', 'user.name', 'github-actions[bot]'], { cwd })
   await exec.exec('git', ['commit', '-m', message], { cwd })
-  await exec.exec('git', ['rev-parse', 'HEAD'])
+  await exec.exec('git', ['rev-parse', 'HEAD'], { cwd })
 }
 
 export const pushByFastForward = async (cwd: string): Promise<number> => {


### PR DESCRIPTION
Follow up https://github.com/quipper/monorepo-deploy-actions/pull/1126.

To fix the error:

```
/usr/bin/git rev-parse HEAD
fatal: not a git repository (or any of the parent directories): .git
Error: Error: The process '/usr/bin/git' failed with exit code 128
```
