### PR TITLE
Fix retry of delete-pull-request-namespaces

### DIFF
--- a/delete-pull-request-namespaces/src/applications.ts
+++ b/delete-pull-request-namespaces/src/applications.ts
@@ -19,7 +19,7 @@ type DeleteNamespaceApplicationsOptions = {
 }
 
 export const deleteNamespaceApplicationsWithRetry = async (opts: DeleteNamespaceApplicationsOptions) =>
-  await retryExponential(deleteNamespaceApplications(opts), {
+  await retryExponential(() => deleteNamespaceApplications(opts), {
     maxAttempts: 5,
     waitMs: 10000,
   })

--- a/delete-pull-request-namespaces/src/retry.ts
+++ b/delete-pull-request-namespaces/src/retry.ts
@@ -5,9 +5,9 @@ type RetrySpec = {
   waitMs: number
 }
 
-export const retryExponential = async <T>(f: Promise<T | Error>, spec: RetrySpec): Promise<T> => {
+export const retryExponential = async <T>(f: () => Promise<T | Error>, spec: RetrySpec): Promise<T> => {
   for (let attempt = 1; ; attempt++) {
-    const value = await f
+    const value = await f()
     if (!(value instanceof Error)) {
       return value
     }


### PR DESCRIPTION
## Problem to solve
When the fast-forward is failed in delete-pull-request-namespaces action, it should retry but not.

```console
/usr/bin/git push origin
To https://github.com/...
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/...'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Warning: Retrying after 163 ms: Error: git-push returned code 1
Warning: Retrying after 5815 ms: Error: git-push returned code 1
Warning: Retrying after 3538 ms: Error: git-push returned code 1
Warning: Retrying after 1927 ms: Error: git-push returned code 1
Error: Error: git-push returned code 1
```

Follow up https://github.com/quipper/monorepo-deploy-actions/pull/1126.