### PR TITLE
Keep branches of open pull requests (cleanup-closed-pull-requests)

### DIFF
--- a/cleanup-closed-pull-requests/README.md
+++ b/cleanup-closed-pull-requests/README.md
@@ -87,7 +87,7 @@ It deletes branches by the following rules:
 
 - If a pull request is open, this action does not delete it.
   The namespace branch should be preserved, because it will be deployed again in the future.
-- If a pull request is still deployed, this action does not delete it.
+- If a pull request is closed but still deployed, this action does not delete it.
 - Otherwise, delete it.
 
 ## Specification

--- a/cleanup-closed-pull-requests/README.md
+++ b/cleanup-closed-pull-requests/README.md
@@ -86,6 +86,7 @@ ns/monorepo/pr/pr-102
 It deletes branches by the following rules:
 
 - If a pull request is open, this action does not delete it.
+  The namespace branch should be preserved, because it will be deployed again in the future.
 - If a pull request is still deployed, this action does not delete it.
 - Otherwise, delete it.
 

--- a/cleanup-closed-pull-requests/README.md
+++ b/cleanup-closed-pull-requests/README.md
@@ -85,7 +85,8 @@ ns/monorepo/pr/pr-102
 
 It deletes branches by the following rules:
 
-- If both namespace application and namespace branch exist, this action does not delete it.
+- If a pull request is open, this action does not delete it.
+- If a pull request is still deployed, this action does not delete it.
 - Otherwise, delete it.
 
 ## Specification

--- a/cleanup-closed-pull-requests/src/branches.ts
+++ b/cleanup-closed-pull-requests/src/branches.ts
@@ -39,15 +39,15 @@ export const deleteNamespaceBranches = async (opts: DeleteNamespaceBranchesOptio
 }
 
 const shouldDeleteNamespace = (branch: NamespaceBranch, opts: DeleteNamespaceBranchesOptions) => {
-  // Keep the branch if the pull request is open.
-  // It will be deployed again in the future.
+  // If a pull request is open, do not delete it.
+  // The namespace branch should be preserved, because it will be deployed again in the future.
   if (opts.openPullRequestNumbers.includes(branch.pullRequestNumber)) {
     core.info(`Skip deletion of namespace ${branch.namespace}, because it is open`)
     return false
   }
 
-  // Keep the branch if the application exists.
-  // See application.ts
+  // If a pull request is closed but still deployed, do not delete it.
+  // See also application.ts
   if (opts.deployedPullRequestNumbers.includes(branch.pullRequestNumber)) {
     core.info(`Skip deletion of namespace ${branch.namespace}, because it is still deployed`)
     return false

--- a/cleanup-closed-pull-requests/src/branches.ts
+++ b/cleanup-closed-pull-requests/src/branches.ts
@@ -10,6 +10,7 @@ type DeleteNamespaceBranchesOptions = {
   sourceRepositoryName: string
   destinationRepository: string
   destinationRepositoryToken: string
+  openPullRequestNumbers: number[]
   deployedPullRequestNumbers: number[]
   dryRun: boolean
 }
@@ -38,6 +39,15 @@ export const deleteNamespaceBranches = async (opts: DeleteNamespaceBranchesOptio
 }
 
 const shouldDeleteNamespace = (branch: NamespaceBranch, opts: DeleteNamespaceBranchesOptions) => {
+  // Keep the branch if the pull request is open.
+  // It will be deployed again in the future.
+  if (opts.openPullRequestNumbers.includes(branch.pullRequestNumber)) {
+    core.info(`Skip deletion of namespace ${branch.namespace}, because it is open`)
+    return false
+  }
+
+  // Keep the branch if the application exists.
+  // See application.ts
   if (opts.deployedPullRequestNumbers.includes(branch.pullRequestNumber)) {
     core.info(`Skip deletion of namespace ${branch.namespace}, because it is still deployed`)
     return false

--- a/cleanup-closed-pull-requests/src/run.ts
+++ b/cleanup-closed-pull-requests/src/run.ts
@@ -38,6 +38,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
   await deleteNamespaceBranches({
     overlay: inputs.overlay,
     namespacePrefix: inputs.namespacePrefix,
+    openPullRequestNumbers,
     deployedPullRequestNumbers,
     sourceRepositoryName,
     destinationRepository: inputs.destinationRepository,


### PR DESCRIPTION
Follow up https://github.com/quipper/monorepo-deploy-actions/pull/1136.

## Problem to solve
I tested the action against our repository, and noticed that the action was trying to delete open pull requests.

## Change
Keep a branch if the pull request is open. It will be deployed again by adding `deploy` label in the future.
