### PR TITLE
Update node version

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn format

--- a/.github/workflows/cleanup-closed-pull-requests.yaml
+++ b/.github/workflows/cleanup-closed-pull-requests.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/create-deploy-pull-request.yaml
+++ b/.github/workflows/create-deploy-pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/delete-pull-request-namespaces.yaml
+++ b/.github/workflows/delete-pull-request-namespaces.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/environment-matrix.yaml
+++ b/.github/workflows/environment-matrix.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/git-push-namespace.yaml
+++ b/.github/workflows/git-push-namespace.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/git-push-service.yaml
+++ b/.github/workflows/git-push-service.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/git-push-services-from-prebuilt.yaml
+++ b/.github/workflows/git-push-services-from-prebuilt.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/git-push-services-patch.yaml
+++ b/.github/workflows/git-push-services-patch.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/open-backport-pull-request.yaml
+++ b/.github/workflows/open-backport-pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn workspaces run ci:package

--- a/.github/workflows/resolve-aws-secret-version.yaml
+++ b/.github/workflows/resolve-aws-secret-version.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/substitute.yaml
+++ b/.github/workflows/substitute.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn test
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn
       - run: yarn build

--- a/cleanup-closed-pull-requests/action.yaml
+++ b/cleanup-closed-pull-requests/action.yaml
@@ -36,5 +36,5 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/create-deploy-pull-request/action.yaml
+++ b/create-deploy-pull-request/action.yaml
@@ -30,5 +30,5 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/delete-pull-request-namespaces/action.yaml
+++ b/delete-pull-request-namespaces/action.yaml
@@ -45,5 +45,5 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/environment-matrix/action.yaml
+++ b/environment-matrix/action.yaml
@@ -8,5 +8,5 @@ outputs:
   json:
     description: JSON string of environments
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/git-push-namespace/action.yaml
+++ b/git-push-namespace/action.yaml
@@ -19,5 +19,5 @@ inputs:
     required: true
     default: ${{ github.token }}
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/git-push-service/action.yaml
+++ b/git-push-service/action.yaml
@@ -48,5 +48,5 @@ outputs:
     description: URL of pull request if created
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/git-push-services-from-prebuilt/action.yaml
+++ b/git-push-services-from-prebuilt/action.yaml
@@ -20,5 +20,5 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/git-push-services-patch/action.yaml
+++ b/git-push-services-patch/action.yaml
@@ -26,5 +26,5 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/open-backport-pull-request/action.yaml
+++ b/open-backport-pull-request/action.yaml
@@ -15,5 +15,5 @@ outputs:
   head-branch:
     description: The head branch of the opened Pull Request
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "@actions/core": "1.10.1"
   },
   "devDependencies": {
-    "@tsconfig/node16": "16.1.1",
+    "@tsconfig/node20": "20.1.2",
     "@types/jest": "29.5.5",
-    "@types/node": "16.18.58",
+    "@types/node": "20.1.2",
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
     "@vercel/ncc": "0.38.0",
@@ -27,6 +27,6 @@
     "*"
   ],
   "engines": {
-    "node": "16.x"
+    "node": "20.x"
   }
 }

--- a/resolve-aws-secret-version/action.yaml
+++ b/resolve-aws-secret-version/action.yaml
@@ -5,5 +5,5 @@ inputs:
     description: glob pattern(s) to manifest(s)
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/substitute/action.yaml
+++ b/substitute/action.yaml
@@ -11,5 +11,5 @@ inputs:
     description: variable(s) in form of multiline string with KEY=VALUE
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/template/action.yaml
+++ b/template/action.yaml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json"
+  "extends": "@tsconfig/node20/tsconfig.json"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,10 +1989,10 @@
     "@smithy/util-buffer-from" "^2.0.0"
     tslib "^2.5.0"
 
-"@tsconfig/node16@16.1.1":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-16.1.1.tgz#b9322bcacf7b7a487ab4e078f88455bde47f3780"
-  integrity sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==
+"@tsconfig/node20@20.1.2":
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node20/-/node20-20.1.2.tgz#b93128c411d38e9507035255195bc8a6718541e3"
+  integrity sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==
 
 "@types/babel__core@^7.1.14":
   version "7.1.14"
@@ -2086,10 +2086,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@16.18.58":
-  version "16.18.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.58.tgz#bf66f63983104ed57c754f4e84ccaf16f8235adb"
-  integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
+"@types/node@20.1.2":
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
+  integrity sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==
 
 "@types/semver@^7.5.0":
   version "7.5.0"


### PR DESCRIPTION
## Problem to solve

- Unable to update @actions/github due to outdated node version used in this repository
  - ref: https://github.com/quipper/monorepo-deploy-actions/pull/1151
- node v16 is [end of life](https://nodejs.dev/en/about/releases/)

## Change

- Update node version from `16` to `20`
  - Select `node20` because `node18` is not defined in [JSON Schema](https://json.schemastore.org/github-action.json)