### PR TITLE
Add bootstrap-pull-request action

### DIFF
--- a/.github/workflows/bootstrap-pull-request.yaml
+++ b/.github/workflows/bootstrap-pull-request.yaml
@@ -1,0 +1,92 @@
+name: bootstrap-pull-request
+
+on:
+  pull_request:
+    paths:
+      - bootstrap-pull-request/**
+      - '*.json'
+      - .github/workflows/bootstrap-pull-request.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - bootstrap-pull-request/**
+      - '*.json'
+      - .github/workflows/bootstrap-pull-request.yaml
+
+defaults:
+  run:
+    working-directory: bootstrap-pull-request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn
+      - run: yarn test
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn
+      - run: yarn build
+      - run: yarn package
+
+      - run: |
+          git config --global user.email 'github-actions@github.com'
+          git config --global user.name 'github-actions'
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          ref: ${{ github.head_ref }} # avoid "shallow update not allowed" error
+          path: prebuilt-branch
+      - name: Set up an prebuilt branch
+        working-directory: prebuilt-branch
+        run: |
+          mkdir -vp services/a
+          mkdir -vp services/b
+          touch services/a/generated.yaml
+          touch services/b/generated.yaml
+          git add .
+          git commit -m "Add prebuilt branch for e2e-test of ${GITHUB_REF}"
+          git push origin "HEAD:refs/heads/prebuilt/monorepo-deploy-actions/overlay-${{ github.run_id }}"
+
+      - uses: ./bootstrap-pull-request
+        with:
+          overlay: overlay-${{ github.run_id }}
+          namespace: pr-${{ github.event.number }}
+          destination-repository: ${{ github.repository }}
+          namespace-manifest: bootstrap-pull-request/tests/fixtures/namespace.yaml
+          substitute-variables: NAMESPACE=pr-${{ github.event.number }}
+
+      # the action should be idempotent
+      - uses: ./bootstrap-pull-request
+        with:
+          overlay: overlay-${{ github.run_id }}
+          namespace: pr-${{ github.event.number }}
+          destination-repository: ${{ github.repository }}
+          namespace-manifest: bootstrap-pull-request/tests/fixtures/namespace.yaml
+          substitute-variables: NAMESPACE=pr-${{ github.event.number }}
+
+      - name: Clean up the namespace branch
+        continue-on-error: true
+        if: always()
+        run: |
+          git push origin --delete "refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.number }}"
+      - name: Clean up the prebuilt branch
+        continue-on-error: true
+        if: always()
+        run: |
+          git push origin --delete "refs/heads/prebuilt/monorepo-deploy-actions/overlay-${{ github.run_id }}"

--- a/bootstrap-pull-request/README.md
+++ b/bootstrap-pull-request/README.md
@@ -1,0 +1,137 @@
+# bootstrap-pull-request [![bootstrap-pull-request](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/bootstrap-pull-request.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/bootstrap-pull-request.yaml)
+
+This is an action to bootstrap the pull request namespace.
+When a pull request is created or updated, this action copies the service manifests from the prebuilt branch.
+
+```mermaid
+graph LR
+  subgraph Source repository
+    SourceNamespaceManifest[Namespace manifest]
+  end
+  subgraph Destination repository
+    subgraph Prebuilt branch
+      PrebuiltServiceManifest[Service manifest]
+    end
+    subgraph Namespace branch
+      ApplicationManifest[Application manifest]
+      ServiceManifest[Service manifest]
+      NamespaceManifest[Namespace manifest]
+    end
+  end
+  PrebuiltServiceManifest --Copy--> ServiceManifest
+  SourceNamespaceManifest --Copy--> NamespaceManifest
+```
+
+## Getting Started
+
+To bootstrap the pull request namespace,
+
+```yaml
+name: pr-namespace / bootstrap
+
+on:
+  pull_request:
+
+jobs:
+  bootstrap-pull-request:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: quipper/monorepo-deploy-actions/bootstrap-pull-request@v1
+        with:
+          overlay: pr
+          namespace: pr-${{ github.event.number }}
+          destination-repository: octocat/generated-manifests
+          destination-repository-token: ${{ steps.destination-repository-github-app.outputs.token }}
+          namespace-manifest: deploy-config/overlays/pr/namespace.yaml
+          substitute-variables: |
+            NAMESPACE=pr-${{ github.event.number }}
+```
+
+This action creates a namespace branch into the destination repository.
+
+```
+ns/${source-repository}/${overlay}/${namespace-prefix}${pull-request-number}
+```
+
+It creates the following directory structure.
+
+```
+.
+├── applications
+|   ├── namespace.yaml
+|   └── ${namespace}--${service}.yaml
+└── services
+    └── ${service}
+        └── generated.yaml
+```
+
+It assumes that the below name of prebuilt branch exists in the destination repository.
+
+```
+prebuilt/${source-repository}/${overlay}
+```
+
+It bootstraps the namespace branch by the following steps:
+
+- Copy the services from prebuilt branch.
+- Write the namespace manifest
+
+### Copy the services from prebuilt branch
+
+This action copies the services from prebuilt branch to the namespace branch.
+
+For example, if the prebuilt branch has 2 services `backend` and `frontend`,
+the namespace branch will be the below structure.
+
+```
+.
+├── applications
+|   ├── pr-123--backend.yaml
+|   └── pr-123--frontend.yaml
+└── services
+    ├── backend
+    |   └── generated.yaml
+    └── frontend
+        └── generated.yaml
+```
+
+All placeholders will be replaced during copying the service manifests.
+For example, if `NAMESPACE=pr-123` is given by `substitute-variables` input,
+this action will replace `${NAMESPACE}` with `pr-123`. 
+
+If a service was pushed by `git-push-service` action,
+this action does not overwrite it.
+
+**Case 1**: If a service is not changed in a pull request,
+
+1. When a pull request is created, this action copies the service from prebuilt branch.
+1. When the pull request is updated, this action copies the service from prebuilt branch.
+   This is needed to follow the latest change of prebuilt branch.
+
+**Case 2**: If a service is changed in a pull request,
+
+1. When a pull request is created,
+   - This action copies the service from prebuilt branch.
+   - `git-push-service` action overwrites the service.
+1. When the pull request is synchronized,
+   - This action does not overwrite the service.
+
+### Write the namespace manifest
+
+This action copies the namespace manifest to path `/applications/namespace.yaml` in the namespace branch.
+
+```
+.
+└── applications
+    └── namespace.yaml
+```
+
+All placeholders will be replaced during copying the namespace manifest.
+For example, if `NAMESPACE=pr-123` is given by `substitute-variables` input,
+this action will replace `${NAMESPACE}` with `pr-123`. 
+
+## Specification
+
+See [action.yaml](action.yaml).

--- a/bootstrap-pull-request/action.yaml
+++ b/bootstrap-pull-request/action.yaml
@@ -1,0 +1,31 @@
+name: bootstrap-pull-request
+description: bootstrap the pull request namespace
+
+inputs:
+  overlay:
+    description: Name of overlay
+    required: true
+  namespace:
+    description: Name of namespace
+    required: true
+  source-repository:
+    description: Source repository
+    required: true
+    default: ${{ github.repository }}
+  destination-repository:
+    description: Destination repository
+    required: true
+  destination-repository-token:
+    description: GitHub token for destination repository
+    required: true
+    default: ${{ github.token }}
+  namespace-manifest:
+    description: Path to namespace manifest (optional)
+    required: false
+  substitute-variables:
+    description: Pairs of key=value to substitute the prebuilt manifests (multiline)
+    required: false
+
+runs:
+  using: 'node20'
+  main: 'dist/index.js'

--- a/bootstrap-pull-request/jest.config.js
+++ b/bootstrap-pull-request/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  clearMocks: true,
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  verbose: true,
+}

--- a/bootstrap-pull-request/package.json
+++ b/bootstrap-pull-request/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bootstrap-pull-request",
+  "version": "0.0.0",
+  "private": true,
+  "main": "lib/src/main.js",
+  "scripts": {
+    "build": "tsc",
+    "package": "ncc build --source-map --license licenses.txt",
+    "test": "jest",
+    "ci:package": "yarn build && yarn package"
+  },
+  "dependencies": {
+    "@actions/core": "1.10.1"
+  }
+}

--- a/bootstrap-pull-request/src/git.ts
+++ b/bootstrap-pull-request/src/git.ts
@@ -1,0 +1,80 @@
+import * as core from '@actions/core'
+import * as exec from '@actions/exec'
+import * as os from 'os'
+import * as path from 'path'
+import { promises as fs } from 'fs'
+
+type CheckoutOptions = {
+  repository: string
+  branch: string
+  token: string
+}
+
+export const checkout = async (opts: CheckoutOptions) => {
+  const cwd = await fs.mkdtemp(path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'git-'))
+  core.info(`Cloning ${opts.repository} into ${cwd}`)
+  await exec.exec('git', ['version'], { cwd })
+  await exec.exec('git', ['init', '--initial-branch', opts.branch], { cwd })
+  await exec.exec('git', ['config', '--local', 'gc.auto', '0'], { cwd })
+  await exec.exec('git', ['remote', 'add', 'origin', `https://github.com/${opts.repository}`], { cwd })
+  const credentials = Buffer.from(`x-access-token:${opts.token}`).toString('base64')
+  core.setSecret(credentials)
+  await exec.exec(
+    'git',
+    ['config', '--local', 'http.https://github.com/.extraheader', `AUTHORIZATION: basic ${credentials}`],
+    { cwd },
+  )
+  await exec.exec(
+    'git',
+    ['fetch', '--no-tags', '--depth=1', 'origin', `+refs/heads/${opts.branch}:refs/remotes/origin/${opts.branch}`],
+    { cwd },
+  )
+  await exec.exec('git', ['checkout', opts.branch], { cwd })
+  return cwd
+}
+
+export const checkoutOrInitRepository = async (opts: CheckoutOptions) => {
+  const cwd = await fs.mkdtemp(path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'git-'))
+  core.info(`Cloning ${opts.repository} into ${cwd}`)
+  await exec.exec('git', ['version'], { cwd })
+  await exec.exec('git', ['init', '--initial-branch', opts.branch], { cwd })
+  await exec.exec('git', ['config', '--local', 'gc.auto', '0'], { cwd })
+  await exec.exec('git', ['remote', 'add', 'origin', `https://github.com/${opts.repository}`], { cwd })
+  const credentials = Buffer.from(`x-access-token:${opts.token}`).toString('base64')
+  core.setSecret(credentials)
+  await exec.exec(
+    'git',
+    ['config', '--local', 'http.https://github.com/.extraheader', `AUTHORIZATION: basic ${credentials}`],
+    { cwd },
+  )
+  const code = await exec.exec(
+    'git',
+    ['fetch', '--no-tags', '--depth=1', 'origin', `+refs/heads/${opts.branch}:refs/remotes/origin/${opts.branch}`],
+    { cwd, ignoreReturnCode: true },
+  )
+  if (code === 0) {
+    await exec.exec('git', ['checkout', opts.branch], { cwd })
+    return cwd
+  }
+  // If the remote branch does not exist, set up the tracking branch.
+  await exec.exec('git', ['config', '--local', `branch.${opts.branch}.remote`, 'origin'], { cwd })
+  await exec.exec('git', ['config', '--local', `branch.${opts.branch}.merge`, `refs/heads/${opts.branch}`], { cwd })
+  return cwd
+}
+
+export const status = async (cwd: string): Promise<string> => {
+  const output = await exec.getExecOutput('git', ['status', '--porcelain'], { cwd })
+  return output.stdout.trim()
+}
+
+export const commit = async (cwd: string, message: string): Promise<void> => {
+  await exec.exec('git', ['add', '.'], { cwd })
+  await exec.exec('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { cwd })
+  await exec.exec('git', ['config', 'user.name', 'github-actions[bot]'], { cwd })
+  await exec.exec('git', ['commit', '-m', message], { cwd })
+  await exec.exec('git', ['rev-parse', 'HEAD'], { cwd })
+}
+
+export const pushByFastForward = async (cwd: string): Promise<number> => {
+  return await exec.exec('git', ['push', 'origin'], { cwd, ignoreReturnCode: true })
+}

--- a/bootstrap-pull-request/src/main.ts
+++ b/bootstrap-pull-request/src/main.ts
@@ -1,0 +1,19 @@
+import * as core from '@actions/core'
+import { run } from './run'
+
+const main = async (): Promise<void> => {
+  await run({
+    overlay: core.getInput('overlay', { required: true }),
+    namespace: core.getInput('namespace', { required: true }),
+    sourceRepository: core.getInput('source-repository', { required: true }),
+    destinationRepository: core.getInput('destination-repository', { required: true }),
+    destinationRepositoryToken: core.getInput('destination-repository-token', { required: true }),
+    namespaceManifest: core.getInput('namespace-manifest') || undefined,
+    substituteVariables: core.getMultilineInput('substitute-variables'),
+  })
+}
+
+main().catch((e: Error) => {
+  core.setFailed(e)
+  console.error(e)
+})

--- a/bootstrap-pull-request/src/namespace.ts
+++ b/bootstrap-pull-request/src/namespace.ts
@@ -1,0 +1,23 @@
+import * as core from '@actions/core'
+import * as io from '@actions/io'
+import { promises as fs } from 'fs'
+
+type Inputs = {
+  namespaceManifest: string
+  namespaceDirectory: string
+  substituteVariables: Map<string, string>
+}
+
+export const writeNamespaceManifest = async (inputs: Inputs): Promise<void> => {
+  core.info(`Reading ${inputs.namespaceManifest}`)
+  let content = (await fs.readFile(inputs.namespaceManifest)).toString()
+  for (const [k, v] of inputs.substituteVariables) {
+    const placeholder = '${' + k + '}'
+    content = content.replaceAll(placeholder, v)
+  }
+
+  const namespacePath = `${inputs.namespaceDirectory}/applications/namespace.yaml`
+  core.info(`Writing to ${namespacePath}`)
+  await io.mkdirP(`${inputs.namespaceDirectory}/applications`)
+  await fs.writeFile(namespacePath, content)
+}

--- a/bootstrap-pull-request/src/prebuilt.ts
+++ b/bootstrap-pull-request/src/prebuilt.ts
@@ -1,0 +1,147 @@
+import * as core from '@actions/core'
+import * as io from '@actions/io'
+import * as yaml from 'js-yaml'
+import { promises as fs } from 'fs'
+
+type Inputs = {
+  overlay: string
+  namespace: string
+  sourceRepositoryName: string
+  destinationRepository: string
+  prebuiltDirectory: string
+  namespaceDirectory: string
+  substituteVariables: Map<string, string>
+}
+
+export const copyServicesFromPrebuilt = async (inputs: Inputs): Promise<void> => {
+  core.info(`Finding services in ${inputs.prebuiltDirectory}/services`)
+  const services = (await fs.readdir(`${inputs.prebuiltDirectory}/services`, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+  for (const service of services) {
+    if (await shouldWriteService(inputs, service)) {
+      core.info(`Writing the service manifest of ${service}`)
+      await writeServiceManifest(inputs, service)
+      core.info(`Writing the application manifest of ${service}`)
+      await writeApplicationManifest(inputs, service)
+    }
+  }
+}
+
+const shouldWriteService = async (inputs: Inputs, service: string) => {
+  const applicationManifestPath = `${inputs.namespaceDirectory}/applications/${inputs.namespace}--${service}.yaml`
+  const applicationManifest = await readContentOrNull(applicationManifestPath)
+  if (applicationManifest === null) {
+    core.info(`Application manifest ${applicationManifestPath} does not exist`)
+    return true
+  }
+
+  // If the service was pushed by git-push-service, don't overwrite it.
+  if (/^ *github\.action: git-push-service$/m.test(applicationManifest)) {
+    core.info(`Application manifest ${applicationManifestPath} was pushed by git-push-service action`)
+    return false
+  }
+
+  // If the service was pushed by this action,
+  // overwrite the service to follow the latest change of prebuilt branch.
+  core.info(`Application manifest ${applicationManifestPath} was pushed by this action`)
+  return true
+}
+
+const readContentOrNull = async (f: string): Promise<string | null> => {
+  try {
+    const b = await fs.readFile(f)
+    return b.toString()
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error) {
+      const e = error as { code: string }
+      if (e.code === 'ENOENT') {
+        return null
+      }
+    }
+    throw error
+  }
+}
+
+const writeServiceManifest = async (inputs: Inputs, service: string) => {
+  const filenames = (await fs.readdir(`${inputs.prebuiltDirectory}/services/${service}`, { withFileTypes: true }))
+    .filter((e) => e.isFile())
+    .map((e) => e.name)
+
+  for (const filename of filenames) {
+    const prebuiltPath = `${inputs.prebuiltDirectory}/services/${service}/${filename}`
+    core.info(`Reading ${prebuiltPath}`)
+    let content = (await fs.readFile(prebuiltPath)).toString()
+    for (const [k, v] of inputs.substituteVariables) {
+      const placeholder = '${' + k + '}'
+      content = content.replaceAll(placeholder, v)
+    }
+    const namespacePath = `${inputs.namespaceDirectory}/services/${service}/${filename}`
+    core.info(`Writing to ${namespacePath}`)
+    await io.mkdirP(`${inputs.namespaceDirectory}/services/${service}`)
+    await fs.writeFile(namespacePath, content)
+  }
+}
+
+type ArgoCDApplication = {
+  apiVersion: string
+  kind: string
+  metadata: {
+    name: string
+    namespace: string
+    annotations?: { [key: string]: string }
+    finalizers: string[]
+  }
+  spec: {
+    project: string
+    source: {
+      repoURL: string
+      targetRevision: string
+      path: string
+    }
+    destination: {
+      server: string
+      namespace: string
+    }
+    syncPolicy: {
+      automated: {
+        prune: boolean
+      }
+    }
+  }
+}
+
+const writeApplicationManifest = async (inputs: Inputs, service: string) => {
+  const application: ArgoCDApplication = {
+    apiVersion: 'argoproj.io/v1alpha1',
+    kind: 'Application',
+    metadata: {
+      name: `${inputs.namespace}--${service}`,
+      namespace: 'argocd',
+      finalizers: ['resources-finalizer.argocd.argoproj.io'],
+      annotations: { 'github.action': 'bootstrap-pull-request' },
+    },
+    spec: {
+      project: inputs.sourceRepositoryName,
+      source: {
+        repoURL: `https://github.com/${inputs.destinationRepository}.git`,
+        targetRevision: `ns/${inputs.sourceRepositoryName}/${inputs.overlay}/${inputs.namespace}`,
+        path: `services/${service}`,
+      },
+      destination: {
+        server: `https://kubernetes.default.svc`,
+        namespace: inputs.namespace,
+      },
+      syncPolicy: {
+        automated: {
+          prune: true,
+        },
+      },
+    },
+  }
+
+  const destination = `${inputs.namespaceDirectory}/applications/${application.metadata.name}.yaml`
+  core.info(`Writing to ${destination}`)
+  await io.mkdirP(`${inputs.namespaceDirectory}/applications`)
+  await fs.writeFile(destination, yaml.dump(application))
+}

--- a/bootstrap-pull-request/src/retry.ts
+++ b/bootstrap-pull-request/src/retry.ts
@@ -1,0 +1,26 @@
+import * as core from '@actions/core'
+
+type RetrySpec = {
+  maxAttempts: number
+  waitMs: number
+}
+
+export const retryExponential = async <T>(f: () => Promise<T | Error>, spec: RetrySpec): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    const value = await f()
+    if (!(value instanceof Error)) {
+      return value
+    }
+
+    const retryOver = attempt >= spec.maxAttempts
+    if (retryOver) {
+      throw value
+    }
+
+    const waitMs = Math.ceil(Math.pow(attempt, 2) + Math.random() * spec.waitMs)
+    core.warning(`Retrying after ${waitMs} ms: ${String(value)}`)
+    await sleep(waitMs)
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/bootstrap-pull-request/src/run.ts
+++ b/bootstrap-pull-request/src/run.ts
@@ -1,0 +1,95 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import * as git from './git'
+import { copyServicesFromPrebuilt } from './prebuilt'
+import { retryExponential } from './retry'
+import { writeNamespaceManifest } from './namespace'
+
+type Inputs = {
+  overlay: string
+  namespace: string
+  sourceRepository: string
+  destinationRepository: string
+  destinationRepositoryToken: string
+  namespaceManifest: string | undefined
+  substituteVariables: string[]
+}
+
+export const run = async (inputs: Inputs): Promise<void> =>
+  await retryExponential(() => bootstrapNamespace(inputs), {
+    maxAttempts: 50,
+    waitMs: 10000,
+  })
+
+const bootstrapNamespace = async (inputs: Inputs): Promise<void | Error> => {
+  core.info(`Checking out the prebuilt branch`)
+  const prebuiltDirectory = await checkoutPrebuiltBranch(inputs)
+  core.info(`Checking out the namespace branch`)
+  const namespaceDirectory = await checkoutNamespaceBranch(inputs)
+
+  const substituteVariables = parseSubstituteVariables(inputs.substituteVariables)
+  const [, sourceRepositoryName] = inputs.sourceRepository.split('/')
+
+  // TODO: consider the garbage collection of the outdated services
+
+  await copyServicesFromPrebuilt({
+    overlay: inputs.overlay,
+    namespace: inputs.namespace,
+    sourceRepositoryName,
+    destinationRepository: inputs.destinationRepository,
+    prebuiltDirectory,
+    namespaceDirectory,
+    substituteVariables,
+  })
+
+  if (inputs.namespaceManifest) {
+    await writeNamespaceManifest({
+      namespaceManifest: inputs.namespaceManifest,
+      namespaceDirectory,
+      substituteVariables,
+    })
+  }
+
+  if ((await git.status(namespaceDirectory)) === '') {
+    core.info('Nothing to commit')
+    return
+  }
+  await git.commit(namespaceDirectory, commitMessage(inputs.namespace))
+  const pushCode = await git.pushByFastForward(namespaceDirectory)
+  if (pushCode > 0) {
+    // Retry from checkout if fast-forward was failed
+    return new Error(`git-push returned code ${pushCode}`)
+  }
+}
+
+const checkoutPrebuiltBranch = async (inputs: Inputs) => {
+  const [, sourceRepositoryName] = inputs.sourceRepository.split('/')
+  return await git.checkout({
+    repository: inputs.destinationRepository,
+    branch: `prebuilt/${sourceRepositoryName}/${inputs.overlay}`,
+    token: inputs.destinationRepositoryToken,
+  })
+}
+
+const checkoutNamespaceBranch = async (inputs: Inputs) => {
+  const [, sourceRepositoryName] = inputs.sourceRepository.split('/')
+  return await git.checkoutOrInitRepository({
+    repository: inputs.destinationRepository,
+    branch: `ns/${sourceRepositoryName}/${inputs.overlay}/${inputs.namespace}`,
+    token: inputs.destinationRepositoryToken,
+  })
+}
+
+const parseSubstituteVariables = (substituteVariables: string[]): Map<string, string> => {
+  const m = new Map<string, string>()
+  for (const s of substituteVariables) {
+    const k = s.substring(0, s.indexOf('='))
+    const v = s.substring(s.indexOf('=') + 1)
+    m.set(k, v)
+  }
+  return m
+}
+
+const commitMessage = (namespace: string) => `Bootstrap namespace ${namespace}
+${github.context.action}
+${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`

--- a/bootstrap-pull-request/tests/fixtures/namespace.yaml
+++ b/bootstrap-pull-request/tests/fixtures/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}

--- a/bootstrap-pull-request/tests/fixtures/prebuilt/services/a/generated.yaml
+++ b/bootstrap-pull-request/tests/fixtures/prebuilt/services/a/generated.yaml
@@ -1,0 +1,3 @@
+# fixture
+name: a
+namespace: ${NAMESPACE}

--- a/bootstrap-pull-request/tests/fixtures/prebuilt/services/b/generated.yaml
+++ b/bootstrap-pull-request/tests/fixtures/prebuilt/services/b/generated.yaml
@@ -1,0 +1,3 @@
+# fixture
+name: b
+namespace: ${NAMESPACE}

--- a/bootstrap-pull-request/tests/namespace.test.ts
+++ b/bootstrap-pull-request/tests/namespace.test.ts
@@ -1,0 +1,25 @@
+import * as os from 'os'
+import * as path from 'path'
+import { promises as fs } from 'fs'
+import { writeNamespaceManifest } from '../src/namespace'
+
+const readContent = async (filename: string) => (await fs.readFile(filename)).toString()
+
+describe('writeNamespaceManifest', () => {
+  it('should copy the manifests', async () => {
+    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+
+    await writeNamespaceManifest({
+      namespaceManifest: `${__dirname}/fixtures/namespace.yaml`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await readContent(`${namespaceDirectory}/applications/namespace.yaml`)).toBe(`\
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pr-123
+`)
+  })
+})

--- a/bootstrap-pull-request/tests/prebuilt.test.ts
+++ b/bootstrap-pull-request/tests/prebuilt.test.ts
@@ -1,0 +1,159 @@
+import * as os from 'os'
+import * as path from 'path'
+import { promises as fs } from 'fs'
+import { copyServicesFromPrebuilt } from '../src/prebuilt'
+
+const readContent = async (filename: string) => (await fs.readFile(filename)).toString()
+
+describe('copyServicesFromPrebuilt', () => {
+  it('should create the manifests if empty', async () => {
+    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+
+    await copyServicesFromPrebuilt({
+      overlay: 'pr',
+      namespace: 'pr-123',
+      sourceRepositoryName: 'source-repository',
+      destinationRepository: 'octocat/destination-repository',
+      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
+    expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe(serviceA)
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
+    expect(await readContent(`${namespaceDirectory}/services/b/generated.yaml`)).toBe(serviceB)
+  })
+
+  it('should overwrite a manifest if it was pushed by this action', async () => {
+    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+    await fs.mkdir(`${namespaceDirectory}/applications`)
+    await fs.mkdir(`${namespaceDirectory}/services/a`, { recursive: true })
+    await fs.writeFile(`${namespaceDirectory}/applications/pr-123--a.yaml`, applicationA)
+    await fs.writeFile(`${namespaceDirectory}/services/a/generated.yaml`, 'this-should-be-overwritten')
+
+    await copyServicesFromPrebuilt({
+      overlay: 'pr',
+      namespace: 'pr-123',
+      sourceRepositoryName: 'source-repository',
+      destinationRepository: 'octocat/destination-repository',
+      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
+    expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe(serviceA)
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
+    expect(await readContent(`${namespaceDirectory}/services/b/generated.yaml`)).toBe(serviceB)
+  })
+
+  it('should not overwrite a manifest if it was pushed by git-push-service action', async () => {
+    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+    await fs.mkdir(`${namespaceDirectory}/applications`)
+    await fs.mkdir(`${namespaceDirectory}/services/a`, { recursive: true })
+    await fs.writeFile(`${namespaceDirectory}/applications/pr-123--a.yaml`, applicationAPushedByGitPushServiceAction)
+    await fs.writeFile(`${namespaceDirectory}/services/a/generated.yaml`, 'this-should-be-kept')
+
+    await copyServicesFromPrebuilt({
+      overlay: 'pr',
+      namespace: 'pr-123',
+      sourceRepositoryName: 'source-repository',
+      destinationRepository: 'octocat/destination-repository',
+      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(
+      applicationAPushedByGitPushServiceAction,
+    )
+    expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe('this-should-be-kept')
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
+    expect(await readContent(`${namespaceDirectory}/services/b/generated.yaml`)).toBe(serviceB)
+  })
+})
+
+const applicationA = `\
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pr-123--a
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    github.action: bootstrap-pull-request
+spec:
+  project: source-repository
+  source:
+    repoURL: https://github.com/octocat/destination-repository.git
+    targetRevision: ns/source-repository/pr/pr-123
+    path: services/a
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pr-123
+  syncPolicy:
+    automated:
+      prune: true
+`
+
+const applicationAPushedByGitPushServiceAction = `\
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pr-123--a
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    github.action: git-push-service
+spec:
+  project: source-repository
+  source:
+    repoURL: https://github.com/octocat/destination-repository.git
+    targetRevision: ns/source-repository/pr/pr-123
+    path: services/a
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pr-123
+  syncPolicy:
+    automated:
+      prune: true
+`
+
+const applicationB = `\
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pr-123--b
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    github.action: bootstrap-pull-request
+spec:
+  project: source-repository
+  source:
+    repoURL: https://github.com/octocat/destination-repository.git
+    targetRevision: ns/source-repository/pr/pr-123
+    path: services/b
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pr-123
+  syncPolicy:
+    automated:
+      prune: true
+`
+
+const serviceA = `\
+# fixture
+name: a
+namespace: pr-123
+`
+
+const serviceB = `\
+# fixture
+name: b
+namespace: pr-123
+`

--- a/bootstrap-pull-request/tsconfig.json
+++ b/bootstrap-pull-request/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  }
+}

--- a/git-push-services-from-prebuilt/README.md
+++ b/git-push-services-from-prebuilt/README.md
@@ -2,6 +2,10 @@
 
 This is an action to push services from prebuilt manifests.
 
+## Deprecated :warning:
+
+Use `bootstrap-pull-request` action instead.
+
 ## Inputs
 
 | Name                     | Type   | Description                              |


### PR DESCRIPTION
This will add `bootstrap-pull-request` action. See README for details.

## Purpose
- It will supersede [`git-push-services-from-prebuilt`](https://github.com/quipper/monorepo-deploy-actions/tree/main/git-push-services-from-prebuilt) action. A workflow will be simple by using this action.
- I will later add a feature to clean up the outdated services in the namespace branch.
