### PR TITLE
Fix flaky e2e-tests

### DIFF
--- a/.github/workflows/cleanup-closed-pull-requests.yaml
+++ b/.github/workflows/cleanup-closed-pull-requests.yaml
@@ -59,13 +59,13 @@ jobs:
       - name: Set up an overlay branch
         working-directory: overlay-branch
         run: |
-          mkdir -vp monorepo-deploy-actions/pr
-          cd monorepo-deploy-actions/pr
+          mkdir -vp monorepo-deploy-actions/overlay-${{ github.run_id }}
+          cd monorepo-deploy-actions/overlay-${{ github.run_id }}
           touch pr-${{ github.event.pull_request.number }}.yaml   # this should be kept
           touch pr-${{ github.event.pull_request.number }}0.yaml  # this should be deleted
           git add .
           git commit -m "Add overlay branch for e2e-test of ${GITHUB_REF}"
-          git push origin "HEAD:refs/heads/cleanup-closed-pull-requests-${{ github.run_number }}"
+          git push origin "HEAD:refs/heads/cleanup-closed-pull-requests-${{ github.run_id }}"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -78,16 +78,16 @@ jobs:
           git add .
           # set the past commit date to be deleted by action
           GIT_COMMITTER_DATE=2020-03-31T00:00:00Z git commit -m "Add namespace branch for e2e-test of ${GITHUB_REF}"
-          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}"   # this should be kept
-          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}0"  # this should be deleted
+          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}"   # this should be kept
+          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}0"  # this should be deleted
 
       - uses: ./cleanup-closed-pull-requests
         id: cleanup-closed-pull-requests
         with:
-          overlay: pr
+          overlay: overlay-${{ github.run_id }}
           namespace-prefix: pr-
           destination-repository: ${{ github.repository }}
-          destination-branch: cleanup-closed-pull-requests-${{ github.run_number }}
+          destination-branch: cleanup-closed-pull-requests-${{ github.run_id }}
 
       - name: Clean up the overlay branch
         continue-on-error: true
@@ -99,5 +99,5 @@ jobs:
         if: always()
         run: |
           git push origin --delete \
-            "refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}" \
-            "refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}0"
+            "refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}" \
+            "refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}0"

--- a/.github/workflows/cleanup-closed-pull-requests.yaml
+++ b/.github/workflows/cleanup-closed-pull-requests.yaml
@@ -93,7 +93,7 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          git push origin --delete "refs/heads/cleanup-closed-pull-requests-${{ github.run_number }}"
+          git push origin --delete "refs/heads/cleanup-closed-pull-requests-${{ github.run_id }}"
       - name: Clean up the namespace branches
         continue-on-error: true
         if: always()

--- a/.github/workflows/delete-pull-request-namespaces.yaml
+++ b/.github/workflows/delete-pull-request-namespaces.yaml
@@ -59,14 +59,14 @@ jobs:
       - name: Set up an overlay branch
         working-directory: overlay-branch
         run: |
-          mkdir -vp monorepo-deploy-actions/pr
-          cd monorepo-deploy-actions/pr
+          mkdir -vp monorepo-deploy-actions/overlay-${{ github.run_id }}
+          cd monorepo-deploy-actions/overlay-${{ github.run_id }}
           touch pr-1.yaml
           touch pr-2.yaml
           touch pr-${{ github.event.pull_request.number }}.yaml
           git add .
           git commit -m "Add overlay branch for e2e-test of ${GITHUB_REF}"
-          git push origin "HEAD:refs/heads/delete-pull-request-namespaces-${{ github.run_number }}"
+          git push origin "HEAD:refs/heads/delete-pull-request-namespaces-${{ github.run_id }}"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -78,15 +78,15 @@ jobs:
           touch dummy
           git add .
           git commit -m "Add namespace branch for e2e-test of ${GITHUB_REF}"
-          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}"
+          git push origin "HEAD:refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}"
 
       - uses: ./delete-pull-request-namespaces
         id: delete-pull-request-namespaces
         with:
-          overlay: pr
+          overlay: overlay-${{ github.run_id }}
           namespace-prefix: pr-
           destination-repository: ${{ github.repository }}
-          destination-branch: delete-pull-request-namespaces-${{ github.run_number }}
+          destination-branch: delete-pull-request-namespaces-${{ github.run_id }}
           exclude-label: skip-nightly-stop
           remove-label-on-deletion: deploy
 
@@ -94,9 +94,9 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          git push origin --delete "refs/heads/delete-pull-request-namespaces-${{ github.run_number }}"
+          git push origin --delete "refs/heads/delete-pull-request-namespaces-${{ github.run_id }}"
       - name: Clean up the namespace branch
         continue-on-error: true
         if: always()
         run: |
-          git push origin --delete "refs/heads/ns/monorepo-deploy-actions/pr/pr-${{ github.event.pull_request.number }}"
+          git push origin --delete "refs/heads/ns/monorepo-deploy-actions/overlay-${{ github.run_id }}/pr-${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Problem to solve
When the e2e tests of `cleanup-closed-pull-requests` and `delete-pull-request-namespaces` run concurrently, either fails due to the conflict of fixture branch.

For example, see https://github.com/quipper/monorepo-deploy-actions/actions/runs/6554279898/job/17801002496.

```
[renovate/github/workflows-actions-checkout-4.x 1dad16a] Add namespace branch for e2e-test of refs/pull/1164/merge
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 dummy
To https://github.com/quipper/monorepo-deploy-actions
 ! [rejected]        HEAD -> ns/monorepo-deploy-actions/pr/pr-1164 (fetch first)
error: failed to push some refs to 'https://github.com/quipper/monorepo-deploy-actions'
```

This is because the branch `ns/monorepo-deploy-actions/pr/pr-1164` has been updated by other test.

## How to solve
Use a unique branch name.
