### PR TITLE
Clean up outdated applications (bootstrap-pull-request)

### DIFF
--- a/bootstrap-pull-request/README.md
+++ b/bootstrap-pull-request/README.md
@@ -75,10 +75,10 @@ prebuilt/${source-repository}/${overlay}
 
 It bootstraps the namespace branch by the following steps:
 
-- Copy the services from prebuilt branch.
+- Sync the services from prebuilt branch.
 - Write the namespace manifest
 
-### Copy the services from prebuilt branch
+### Sync the services from prebuilt branch
 
 This action copies the services from prebuilt branch to the namespace branch.
 
@@ -117,6 +117,27 @@ this action does not overwrite it.
    - `git-push-service` action overwrites the service.
 1. When the pull request is synchronized,
    - This action does not overwrite the service.
+
+If the namespace branch has the outdated applications, this action will delete them.
+For the below example,
+this action will delete `pr-123--outdated.yaml` because the prebuilt branch does not have `outdated` service.
+
+```
+Prebuilt branch:
+.
+└── services
+    ├── backend
+    └── frontend
+
+Namespace branch:
+.
+├── applications
+|   ├── pr-123--backend.yaml
+|   └── pr-123--frontend.yaml
+|   └── pr-123--outdated.yaml    <-- deleted
+└── services
+    └── ...
+```
 
 ### Write the namespace manifest
 

--- a/bootstrap-pull-request/src/run.ts
+++ b/bootstrap-pull-request/src/run.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import * as git from './git'
-import { copyServicesFromPrebuilt } from './prebuilt'
+import { syncServicesFromPrebuilt } from './prebuilt'
 import { retryExponential } from './retry'
 import { writeNamespaceManifest } from './namespace'
 
@@ -32,7 +32,7 @@ const bootstrapNamespace = async (inputs: Inputs): Promise<void | Error> => {
 
   // TODO: consider the garbage collection of the outdated services
 
-  await copyServicesFromPrebuilt({
+  await syncServicesFromPrebuilt({
     overlay: inputs.overlay,
     namespace: inputs.namespace,
     sourceRepositoryName,

--- a/bootstrap-pull-request/src/run.ts
+++ b/bootstrap-pull-request/src/run.ts
@@ -30,8 +30,6 @@ const bootstrapNamespace = async (inputs: Inputs): Promise<void | Error> => {
   const substituteVariables = parseSubstituteVariables(inputs.substituteVariables)
   const [, sourceRepositoryName] = inputs.sourceRepository.split('/')
 
-  // TODO: consider the garbage collection of the outdated services
-
   await syncServicesFromPrebuilt({
     overlay: inputs.overlay,
     namespace: inputs.namespace,

--- a/bootstrap-pull-request/tests/prebuilt.test.ts
+++ b/bootstrap-pull-request/tests/prebuilt.test.ts
@@ -1,15 +1,17 @@
 import * as os from 'os'
 import * as path from 'path'
 import { promises as fs } from 'fs'
-import { copyServicesFromPrebuilt } from '../src/prebuilt'
+import { syncServicesFromPrebuilt } from '../src/prebuilt'
 
 const readContent = async (filename: string) => (await fs.readFile(filename)).toString()
 
-describe('copyServicesFromPrebuilt', () => {
-  it('should create the manifests if empty', async () => {
-    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+const createEmptyDirectory = async () => await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
 
-    await copyServicesFromPrebuilt({
+describe('syncServicesFromPrebuilt', () => {
+  it('should create the manifests if empty', async () => {
+    const namespaceDirectory = await createEmptyDirectory()
+
+    await syncServicesFromPrebuilt({
       overlay: 'pr',
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
@@ -19,6 +21,7 @@ describe('copyServicesFromPrebuilt', () => {
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
+    expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
     expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe(serviceA)
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
@@ -26,13 +29,13 @@ describe('copyServicesFromPrebuilt', () => {
   })
 
   it('should overwrite a manifest if it was pushed by this action', async () => {
-    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+    const namespaceDirectory = await createEmptyDirectory()
     await fs.mkdir(`${namespaceDirectory}/applications`)
     await fs.mkdir(`${namespaceDirectory}/services/a`, { recursive: true })
     await fs.writeFile(`${namespaceDirectory}/applications/pr-123--a.yaml`, applicationA)
     await fs.writeFile(`${namespaceDirectory}/services/a/generated.yaml`, 'this-should-be-overwritten')
 
-    await copyServicesFromPrebuilt({
+    await syncServicesFromPrebuilt({
       overlay: 'pr',
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
@@ -42,6 +45,7 @@ describe('copyServicesFromPrebuilt', () => {
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
+    expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
     expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe(serviceA)
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
@@ -49,13 +53,13 @@ describe('copyServicesFromPrebuilt', () => {
   })
 
   it('should not overwrite a manifest if it was pushed by git-push-service action', async () => {
-    const namespaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bootstrap-pull-request-'))
+    const namespaceDirectory = await createEmptyDirectory()
     await fs.mkdir(`${namespaceDirectory}/applications`)
     await fs.mkdir(`${namespaceDirectory}/services/a`, { recursive: true })
     await fs.writeFile(`${namespaceDirectory}/applications/pr-123--a.yaml`, applicationAPushedByGitPushServiceAction)
     await fs.writeFile(`${namespaceDirectory}/services/a/generated.yaml`, 'this-should-be-kept')
 
-    await copyServicesFromPrebuilt({
+    await syncServicesFromPrebuilt({
       overlay: 'pr',
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
@@ -65,12 +69,67 @@ describe('copyServicesFromPrebuilt', () => {
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
+    expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(
       applicationAPushedByGitPushServiceAction,
     )
     expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe('this-should-be-kept')
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
     expect(await readContent(`${namespaceDirectory}/services/b/generated.yaml`)).toBe(serviceB)
+  })
+
+  it('should delete an outdated application manifest', async () => {
+    const namespaceDirectory = await createEmptyDirectory()
+    await fs.mkdir(`${namespaceDirectory}/applications`)
+    await fs.writeFile(`${namespaceDirectory}/applications/pr-123--outdated.yaml`, applicationA)
+
+    await syncServicesFromPrebuilt({
+      overlay: 'pr',
+      namespace: 'pr-123',
+      sourceRepositoryName: 'source-repository',
+      destinationRepository: 'octocat/destination-repository',
+      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await fs.readdir(`${namespaceDirectory}/applications`, { recursive: true })).toStrictEqual([
+      'pr-123--a.yaml',
+      'pr-123--b.yaml',
+      // pr-123--outdated.yaml should not exist
+    ])
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
+  })
+
+  it('should not delete an application manifest if it was pushed by git-push-service action', async () => {
+    const namespaceDirectory = await createEmptyDirectory()
+    await fs.mkdir(`${namespaceDirectory}/applications`)
+    await fs.writeFile(
+      `${namespaceDirectory}/applications/pr-123--outdated.yaml`,
+      applicationAPushedByGitPushServiceAction,
+    )
+
+    await syncServicesFromPrebuilt({
+      overlay: 'pr',
+      namespace: 'pr-123',
+      sourceRepositoryName: 'source-repository',
+      destinationRepository: 'octocat/destination-repository',
+      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
+      namespaceDirectory,
+      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
+    })
+
+    expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual([
+      'pr-123--a.yaml',
+      'pr-123--b.yaml',
+      'pr-123--outdated.yaml', // should exist
+    ])
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
+    expect(await readContent(`${namespaceDirectory}/applications/pr-123--outdated.yaml`)).toBe(
+      applicationAPushedByGitPushServiceAction,
+    )
   })
 })
 


### PR DESCRIPTION
## Problem to solve
When a service has been removed from the prebuilt branch, it will remain in the existing namespace branches. It may waste the infrastructure cost.

For example,

1. We remove a service from the prebuilt branch.
1. We add a commit to the existing pull request.
1. The outdated service still exists in the namespace branch of the pull request.

## How to solve
Clean up the outdated applications before copying the services.
