### PR TITLE
Concat manifests (git-push-service)

### DIFF
--- a/git-push-service/README.md
+++ b/git-push-service/README.md
@@ -46,6 +46,8 @@ steps:
       service: foo
 ```
 
+If mutiple manifests are given, this action concatenates them into a single file.
+
 It pushes the following files into a destination repository:
 
 ```

--- a/git-push-service/src/arrange.ts
+++ b/git-push-service/src/arrange.ts
@@ -54,12 +54,13 @@ const arrangeServiceManifests = async (inputs: Inputs): Promise<void> => {
   )
 }
 
-const copyGeneratedManifest = async (manifests: string[], destinationDir: string) => {
+const copyGeneratedManifest = async (manifestPaths: string[], destinationDir: string) => {
+  const manifestContents = await Promise.all(
+    manifestPaths.map(async (manifestPath) => (await fs.readFile(manifestPath)).toString()),
+  )
+  const concatManifest = manifestContents.join('\n---\n')
   await io.mkdirP(destinationDir)
-  for (const f of manifests) {
-    core.info(`copying ${f} to ${destinationDir}`)
-    await io.cp(f, destinationDir)
-  }
+  await fs.writeFile(`${destinationDir}/generated.yaml`, concatManifest)
 }
 
 const putApplicationManifest = async (application: Application, workspace: string) => {

--- a/git-push-service/tests/arrange.test.ts
+++ b/git-push-service/tests/arrange.test.ts
@@ -26,6 +26,27 @@ test('arrange a service manifest', async () => {
   )
 })
 
+it('should concatenate service manifests if multiple are given', async () => {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-action-'))
+
+  await arrangeManifests({
+    workspace,
+    manifests: [path.join(__dirname, `fixtures/a/generated.yaml`), path.join(__dirname, `fixtures/b/generated.yaml`)],
+    branch: `ns/project/overlay/namespace`,
+    namespace: 'namespace',
+    service: 'service',
+    namespaceLevel: false,
+    project: 'project',
+    applicationAnnotations: ['github.ref=refs/heads/main'],
+    destinationRepository: 'octocat/manifests',
+  })
+
+  expect(await readContent(path.join(workspace, `services/service/generated.yaml`))).toBe(`\
+${await readContent(path.join(__dirname, `fixtures/a/generated.yaml`))}
+---
+${await readContent(path.join(__dirname, `fixtures/b/generated.yaml`))}`)
+})
+
 test('overwrite even if a file exists', async () => {
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-action-'))
 


### PR DESCRIPTION
## Problem to solve
When multiple manifests are given to git-push-service action, same filename is overwritten.
For example, `foo/generated.yaml` and `bar/generated.yaml` are given, the last one remains finally.

## How to solve
When multiple manifests are given, it concatenates them into `generated.yaml`.
