### PR TITLE
Accept empty files (substitute, resolve-aws-secret-version)

### DIFF
--- a/resolve-aws-secret-version/README.md
+++ b/resolve-aws-secret-version/README.md
@@ -25,6 +25,8 @@ steps:
       manifests: ${{ steps.kustomize.outputs.directory }}/**/*.yaml
 ```
 
+If no manifest file is matched, this action does nothing.
+
 When the below manifest is given,
 
 ```yaml

--- a/resolve-aws-secret-version/action.yaml
+++ b/resolve-aws-secret-version/action.yaml
@@ -3,7 +3,7 @@ description: resolve AWSSecret versionId placeholders in a manifest
 inputs:
   manifests:
     description: glob pattern(s) to manifest(s)
-    required: true
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/resolve-aws-secret-version/src/main.ts
+++ b/resolve-aws-secret-version/src/main.ts
@@ -3,7 +3,7 @@ import { run } from './run'
 
 async function main(): Promise<void> {
   const inputs = {
-    manifests: core.getInput('manifests', { required: true }),
+    manifests: core.getInput('manifests'),
   }
   await run(inputs)
 }

--- a/substitute/README.md
+++ b/substitute/README.md
@@ -29,6 +29,8 @@ steps:
         NAMESPACE=develop
 ```
 
+If no file is matched, this action does nothing.
+
 ### Path variables
 
 This action tests pattern match to each path when `path-variables-pattern` is set.

--- a/substitute/action.yaml
+++ b/substitute/action.yaml
@@ -3,7 +3,7 @@ description: substitute variable(s) in file(s)
 inputs:
   files:
     description: glob pattern(s) to file(s) in form of multiline string
-    required: true
+    required: false
   path-variables-pattern:
     description: path variable(s) pattern
     required: false

--- a/substitute/src/main.ts
+++ b/substitute/src/main.ts
@@ -3,7 +3,7 @@ import { parseVariables, run } from '../src/run'
 
 async function main(): Promise<void> {
   await run({
-    files: core.getInput('files', { required: true }),
+    files: core.getInput('files'),
     pathVariablesPattern: core.getInput('path-variables-pattern') || undefined,
     variables: parseVariables(core.getMultilineInput('variables', { required: true })),
   })


### PR DESCRIPTION
This PR changes `substitute` action and `resolve-aws-secret-version` action to accept empty files.

Both actions should behave like a filter.
If no file is given in inputs, the action does nothing.
