### PR TITLE
Make `inputs.token` optional (environment-matrix)

### DIFF
--- a/environment-matrix/README.md
+++ b/environment-matrix/README.md
@@ -133,7 +133,7 @@ jobs:
 | --------- | -------------- | ----------------------------------------------------------- |
 | `rules`   | (required)     | YAML string of rules                                        |
 | `service` | (optional)     | Name of service to deploy. If set, create GitHub Deployment |
-| `token`   | `github.token` | GitHub token                                                |
+| `token`   | `github.token` | GitHub token, required if `service` is set                  |
 
 The following fields are available in the rules YAML.
 

--- a/environment-matrix/action.yaml
+++ b/environment-matrix/action.yaml
@@ -8,8 +8,8 @@ inputs:
     description: Name of service. If set, create GitHub Deployment
     required: false
   token:
-    description: GitHub token
-    required: true
+    description: GitHub token, required if service is set
+    required: false
     default: ${{ github.token }}
 outputs:
   json:

--- a/environment-matrix/src/main.ts
+++ b/environment-matrix/src/main.ts
@@ -5,7 +5,7 @@ const main = async (): Promise<void> => {
   const outputs = await run({
     rules: core.getInput('rules', { required: true }),
     service: core.getInput('service'),
-    token: core.getInput('token', { required: true }),
+    token: core.getInput('token'),
   })
   core.setOutput('json', outputs.environments)
 }

--- a/environment-matrix/src/run.ts
+++ b/environment-matrix/src/run.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { Environment, parseRulesYAML } from './rule'
@@ -29,6 +30,7 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
   }
 
   core.info(`Creating GitHub Deployments for environments`)
+  assert(inputs.token, `inputs.token is required`)
   const octokit = getOctokit(inputs.token)
   const environmentsWithDeployments = await createGitHubDeploymentForEnvironments(
     octokit,


### PR DESCRIPTION
Follow up https://github.com/quipper/monorepo-deploy-actions/pull/1180.

## Problem to solve
When `service` is not set, `token` is not required.

## How to solve
Fix the validation.
