### PR TITLE
Remove deprecated option (git-push-service)

### DIFF
--- a/git-push-service/action.yaml
+++ b/git-push-service/action.yaml
@@ -23,11 +23,6 @@ inputs:
   destination-branch:
     description: destination branch (default to ns/REPOSITORY/OVERLAY/NAMESPACE)
     required: false
-  prebuilt:
-    description: push prebuilt manifest
-    required: true
-    default: 'false'
-    deprecationMessage: use destination-branch instead # TODO: deprecated
   update-via-pull-request:
     description: update a branch via a pull request
     required: true

--- a/git-push-service/src/main.ts
+++ b/git-push-service/src/main.ts
@@ -10,7 +10,6 @@ async function main(): Promise<void> {
     applicationAnnotations: core.getMultilineInput('application-annotations'),
     destinationRepository: core.getInput('destination-repository', { required: true }),
     destinationBranch: core.getInput('destination-branch'),
-    prebuilt: core.getBooleanInput('prebuilt', { required: true }), // TODO: deprecated
     updateViaPullRequest: core.getBooleanInput('update-via-pull-request', { required: true }),
     token: core.getInput('token', { required: true }),
   })

--- a/git-push-service/src/run.ts
+++ b/git-push-service/src/run.ts
@@ -17,7 +17,6 @@ type Inputs = {
   applicationAnnotations: string[]
   destinationRepository: string
   destinationBranch: string
-  prebuilt: boolean // TODO: deprecated
   updateViaPullRequest: boolean
   token: string
 }
@@ -59,9 +58,7 @@ const push = async (manifests: string[], inputs: Inputs): Promise<Outputs | Erro
 
   const [owner, repo] = inputs.destinationRepository.split('/')
   const project = github.context.repo.repo
-  let branch = inputs.prebuilt
-    ? `prebuilt/${project}/${inputs.overlay}/${github.context.ref}` // TODO: deprecated
-    : `ns/${project}/${inputs.overlay}/${inputs.namespace}`
+  let branch = `ns/${project}/${inputs.overlay}/${inputs.namespace}`
   if (inputs.destinationBranch) {
     branch = inputs.destinationBranch
   }


### PR DESCRIPTION
## For internal reviewers
I confirmed `prebuilt` is not used as https://github.com/search?q=org%3Aquipper+quipper%2Fmonorepo-deploy-actions%2Fgit-push-service%40v1+prebuilt+NOT+is%3Aarchived&type=code