### PR TITLE
Fix CI error on main branch

### DIFF
--- a/.github/workflows/update-outdated-pull-request-branch.yaml
+++ b/.github/workflows/update-outdated-pull-request-branch.yaml
@@ -43,6 +43,7 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn package
-      - uses: ./update-outdated-pull-request-branch
+      - if: github.event_name == 'pull_request'
+        uses: ./update-outdated-pull-request-branch
         with:
           expiration-days: 7

--- a/.github/workflows/update-outdated-pull-request-branch.yaml
+++ b/.github/workflows/update-outdated-pull-request-branch.yaml
@@ -43,6 +43,7 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn package
+      # update-outdated-pull-request-branch action supports only pull_request event
       - if: github.event_name == 'pull_request'
         uses: ./update-outdated-pull-request-branch
         with:


### PR DESCRIPTION
## Problem to solve
I noticed that the status of main branch is failing.
https://github.com/quipper/monorepo-deploy-actions/commits/main/

<img width="1304" alt="image" src="https://github.com/quipper/monorepo-deploy-actions/assets/321266/8aa25fe2-f105-4140-bdbd-216daa6747e2">

### Cause
It seems the test of `update-outdated-pull-request-branch` is failing.
https://github.com/quipper/monorepo-deploy-actions/actions/runs/7745762305/job/21122484804

```
AssertionError [ERR_ASSERTION]: This action must be run on pull_request event
```
