### PR TITLE
Add skip-ci option

### DIFF
--- a/.github/workflows/open-backport-pull-request.yaml
+++ b/.github/workflows/open-backport-pull-request.yaml
@@ -32,3 +32,10 @@ jobs:
       - run: yarn test
       - run: yarn build
       - run: yarn package
+
+      # Smoke test. This should not create any pull request.
+      - if: github.event_name == 'pull_request'
+        uses: ./open-backport-pull-request
+        with:
+          head-branch: main
+          base-branch: main

--- a/open-backport-pull-request/README.md
+++ b/open-backport-pull-request/README.md
@@ -30,15 +30,23 @@ This action creates a working branch from the latest commit of head branch.
 It creates a pull request from the working branch, because the head branch is protected typically.
 When the pull request is conflicted, you can edit the working branch on GitHub.
 
-## Inputs
+### Skip workflow runs
 
-| Name           | Required | Default           | Description                                  |
-| -------------- | -------- | ----------------- | -------------------------------------------- |
-| `github-token` | `true`   | `github.token`    | GitHub token used for opening a Pull Request |
-| `base-branch`  | `true`   |                   | Base branch of the Pull Request              |
-| `head-branch`  | `true`   | `github.ref_name` | Head branch of the Pull Request              |
+You can set `skip-ci` to skip workflow runs for the backport pull request.
+See https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs for details.
 
-## Outputs
+## Specification
+
+### Inputs
+
+| Name           | Default           | Description                                  |
+| -------------- | ----------------- | -------------------------------------------- |
+| `github-token` | `github.token`    | GitHub token used for opening a Pull Request |
+| `base-branch`  | -                 | Base branch of the Pull Request              |
+| `head-branch`  | `github.ref_name` | Head branch of the Pull Request              |
+| `skip-ci`      | false             | Add `[skip ci]` to the commit message        |
+
+### Outputs
 
 | Name               | Description                                |
 | ------------------ | ------------------------------------------ |

--- a/open-backport-pull-request/action.yaml
+++ b/open-backport-pull-request/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: The head branch for a Pull Request
     required: true
     default: ${{ github.ref_name }}
+  skip-ci:
+    description: Add `[skip ci]` to the commit message
+    required: false
+    default: 'false'
 outputs:
   pull-request-url:
     description: The URL of the opened Pull Request

--- a/open-backport-pull-request/src/main.ts
+++ b/open-backport-pull-request/src/main.ts
@@ -6,6 +6,7 @@ const main = async (): Promise<void> => {
     githubToken: core.getInput('github-token', { required: true }),
     headBranch: core.getInput('head-branch', { required: true }),
     baseBranch: core.getInput('base-branch', { required: true }),
+    skipCI: core.getBooleanInput('skip-ci', { required: true }),
   })
 }
 

--- a/open-backport-pull-request/tests/run.test.ts
+++ b/open-backport-pull-request/tests/run.test.ts
@@ -1,1 +1,43 @@
-test('TODO', () => {})
+import { getCommitMessage } from '../src/run'
+
+describe('getCommitMessage', () => {
+  it('should return the commit message', () => {
+    const params = {
+      headBranch: 'production',
+      baseBranch: 'main',
+      skipCI: false,
+      context: {
+        actor: 'octocat',
+        repo: {
+          owner: 'owner',
+          repo: 'repo',
+        },
+        runId: 1,
+      },
+    }
+    expect(getCommitMessage(params)).toEqual(`Backport from production into main
+
+Created by GitHub Actions
+https://github.com/owner/repo/actions/runs/1`)
+  })
+
+  it('should return the commit message with skip ci', () => {
+    const params = {
+      headBranch: 'production',
+      baseBranch: 'main',
+      skipCI: true,
+      context: {
+        actor: 'octocat',
+        repo: {
+          owner: 'owner',
+          repo: 'repo',
+        },
+        runId: 1,
+      },
+    }
+    expect(getCommitMessage(params)).toEqual(`Backport from production into main [skip ci]
+
+Created by GitHub Actions
+https://github.com/owner/repo/actions/runs/1`)
+  })
+})


### PR DESCRIPTION
## New feature
This will add an option to add `[skip ci]` to the commit message. It will skip workflow runs on the pull request. See https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs.
