### PR TITLE
feat(git-push-services-patch) Add services option to specify services

### DIFF
--- a/git-push-services-patch/README.md
+++ b/git-push-services-patch/README.md
@@ -1,6 +1,6 @@
 # git-push-services-patch
 
-This is an action to push a patch to all services in a namespace.
+This is an action to push a patch to services in a namespace.
 
 ## Inputs
 
@@ -10,9 +10,14 @@ This is an action to push a patch to all services in a namespace.
 | `operation`              | string           | Either `add` or `delete`                 |
 | `overlay`                | string           | Name of overlay                          |
 | `namespace`              | string           | Name of namespace                        |
+| `services`               | multiline string | Names of services to include (optional), If not specified, targets all services  |
 | `exclude-services`       | multiline string | Names of services to exclude (optional)  |
 | `destination-repository` | string           | Destination repository                   |
 | `token`                  | string           | GitHub token (default to `github.token`) |
+
+### Note about `services` and `exclude-services`
+
+If you define both `services` and `exclude-services`, the workflow will only apply services only both filters satisfies.
 
 ## Outputs
 

--- a/git-push-services-patch/src/main.ts
+++ b/git-push-services-patch/src/main.ts
@@ -7,6 +7,7 @@ const main = async (): Promise<void> => {
     operation: operationOf(core.getInput('operation', { required: true })),
     overlay: core.getInput('overlay', { required: true }),
     namespace: core.getInput('namespace', { required: true }),
+    services: core.getMultilineInput('services'),
     excludeServices: core.getMultilineInput('exclude-services'),
     destinationRepository: core.getInput('destination-repository', { required: true }),
     token: core.getInput('token', { required: true }),

--- a/git-push-services-patch/src/patch.ts
+++ b/git-push-services-patch/src/patch.ts
@@ -6,20 +6,21 @@ import * as path from 'path'
 type Inputs = {
   workspace: string
   patch: string
+  services: Set<string>
   excludeServices: Set<string>
 }
 
-export const addToServices = async (inputs: Inputs) => {
+export const addToServices = async (inputs: Inputs): Promise<void> => {
   const services = (await readdirOrEmpty(`${inputs.workspace}/services`))
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
   core.info(`found ${services.length} service(s)`)
 
   for (const service of services) {
-    if (inputs.excludeServices.has(service)) {
-      core.info(`excluded service ${service}`)
+    if (shouldSkipService(service, inputs.services, inputs.excludeServices)) {
       continue
     }
+
     const serviceDirectory = `${inputs.workspace}/services/${service}`
     core.info(`copying the patch into ${serviceDirectory}`)
     await io.cp(inputs.patch, serviceDirectory, { force: true })
@@ -35,14 +36,28 @@ export const deleteFromServices = async (inputs: Inputs) => {
   core.info(`found ${services.length} service(s)`)
 
   for (const service of services) {
-    if (inputs.excludeServices.has(service)) {
-      core.info(`excluded service ${service}`)
+    if (shouldSkipService(service, inputs.services, inputs.excludeServices)) {
       continue
     }
+
     const patchPath = `${inputs.workspace}/services/${service}/${patchBasename}`
     core.info(`removing ${patchPath}`)
     await io.rmRF(patchPath)
   }
+}
+
+const shouldSkipService = (service: string, services: Set<string>, excludeServices: Set<string>) => {
+  if (services.size > 0 && !services.has(service)) {
+    core.info(`skipping ${service} because it is not specified`)
+    return true
+  }
+
+  if (excludeServices.has(service)) {
+    core.info(`excluded service ${service}`)
+    return true
+  }
+
+  return false
 }
 
 const readdirOrEmpty = async (dir: string) => {

--- a/git-push-services-patch/src/run.ts
+++ b/git-push-services-patch/src/run.ts
@@ -12,6 +12,7 @@ type Inputs = {
   operation: Operation
   overlay: string
   namespace: string
+  services: string[]
   excludeServices: string[]
   destinationRepository: string
   token: string
@@ -49,9 +50,19 @@ const push = async (inputs: Inputs): Promise<void | Error> => {
   core.endGroup()
 
   if (inputs.operation === 'add') {
-    await patch.addToServices({ workspace, patch: inputs.patch, excludeServices: new Set(inputs.excludeServices) })
+    await patch.addToServices({
+      workspace,
+      patch: inputs.patch,
+      services: new Set(inputs.services),
+      excludeServices: new Set(inputs.excludeServices),
+    })
   } else if (inputs.operation === 'delete') {
-    await patch.deleteFromServices({ workspace, patch: inputs.patch, excludeServices: new Set(inputs.excludeServices) })
+    await patch.deleteFromServices({
+      workspace,
+      patch: inputs.patch,
+      services: new Set(inputs.services),
+      excludeServices: new Set(inputs.excludeServices),
+    })
   }
 
   const status = await git.status(workspace)

--- a/git-push-services-patch/tests/patch.test.ts
+++ b/git-push-services-patch/tests/patch.test.ts
@@ -12,7 +12,7 @@ describe('addToServices', () => {
     await fs.mkdir(path.join(workspace, `services/a`))
     await fs.mkdir(path.join(workspace, `services/b`))
 
-    await expect(addToServices({ workspace, patch, excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
 
     await fs.access(path.join(workspace, `services/a/kustomization.yaml`))
     await fs.access(path.join(workspace, `services/b/kustomization.yaml`))
@@ -25,15 +25,44 @@ describe('addToServices', () => {
     await fs.mkdir(path.join(workspace, `services/a`))
     await fs.mkdir(path.join(workspace, `services/b`))
 
-    await expect(addToServices({ workspace, patch, excludeServices })).resolves.toBeUndefined()
+    await expect(addToServices({ workspace, patch, services: new Set(), excludeServices })).resolves.toBeUndefined()
 
     await expect(fs.access(path.join(workspace, `services/a/kustomization.yaml`))).rejects.toThrow()
     await fs.access(path.join(workspace, `services/b/kustomization.yaml`))
   })
 
+  test('specify a service', async () => {
+    const services = new Set(['a'])
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
+    await fs.mkdir(path.join(workspace, `services`))
+    await fs.mkdir(path.join(workspace, `services/a`))
+    await fs.mkdir(path.join(workspace, `services/b`))
+
+    await expect(addToServices({ workspace, patch, services, excludeServices: new Set() })).resolves.toBeUndefined()
+
+    await fs.access(path.join(workspace, `services/a/kustomization.yaml`))
+    await expect(fs.access(path.join(workspace, `services/b/kustomization.yaml`))).rejects.toThrow()
+  })
+
+  test('specify and exclude services', async () => {
+    const services = new Set(['a', 'b'])
+    const excludeServices = new Set(['b', 'c'])
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
+    await fs.mkdir(path.join(workspace, `services`))
+    await fs.mkdir(path.join(workspace, `services/a`))
+    await fs.mkdir(path.join(workspace, `services/b`))
+    await fs.mkdir(path.join(workspace, `services/c`))
+
+    await expect(addToServices({ workspace, patch, services, excludeServices })).resolves.toBeUndefined()
+
+    await fs.access(path.join(workspace, `services/a/kustomization.yaml`))
+    await expect(fs.access(path.join(workspace, `services/b/kustomization.yaml`))).rejects.toThrow()
+    await expect(fs.access(path.join(workspace, `services/c/kustomization.yaml`))).rejects.toThrow()
+  })
+
   test('if empty directory', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
-    await expect(addToServices({ workspace, patch, excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
   })
 })
 
@@ -46,7 +75,7 @@ describe('deleteFromServices', () => {
     await fs.writeFile(path.join(workspace, `services/a/kustomization.yaml`), 'dummy')
     await fs.writeFile(path.join(workspace, `services/b/kustomization.yaml`), 'dummy')
 
-    await expect(deleteFromServices({ workspace, patch, excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
 
     await expect(fs.access(path.join(workspace, `services/a/kustomization.yaml`))).rejects.toThrow()
     await expect(fs.access(path.join(workspace, `services/b/kustomization.yaml`))).rejects.toThrow()
@@ -61,7 +90,7 @@ describe('deleteFromServices', () => {
     await fs.writeFile(path.join(workspace, `services/a/kustomization.yaml`), 'dummy')
     await fs.writeFile(path.join(workspace, `services/b/kustomization.yaml`), 'dummy')
 
-    await expect(deleteFromServices({ workspace, patch, excludeServices })).resolves.toBeUndefined()
+    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices })).resolves.toBeUndefined()
 
     await expect(fs.access(path.join(workspace, `services/a/kustomization.yaml`))).rejects.toThrow()
     await fs.access(path.join(workspace, `services/b/kustomization.yaml`))
@@ -69,6 +98,6 @@ describe('deleteFromServices', () => {
 
   test('if empty directory', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
-    await expect(deleteFromServices({ workspace, patch, excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
   })
 })

--- a/git-push-services-patch/tests/patch.test.ts
+++ b/git-push-services-patch/tests/patch.test.ts
@@ -12,7 +12,9 @@ describe('addToServices', () => {
     await fs.mkdir(path.join(workspace, `services/a`))
     await fs.mkdir(path.join(workspace, `services/b`))
 
-    await expect(addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(
+      addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() }),
+    ).resolves.toBeUndefined()
 
     await fs.access(path.join(workspace, `services/a/kustomization.yaml`))
     await fs.access(path.join(workspace, `services/b/kustomization.yaml`))
@@ -62,7 +64,9 @@ describe('addToServices', () => {
 
   test('if empty directory', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
-    await expect(addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(
+      addToServices({ workspace, patch, services: new Set(), excludeServices: new Set() }),
+    ).resolves.toBeUndefined()
   })
 })
 
@@ -75,7 +79,9 @@ describe('deleteFromServices', () => {
     await fs.writeFile(path.join(workspace, `services/a/kustomization.yaml`), 'dummy')
     await fs.writeFile(path.join(workspace, `services/b/kustomization.yaml`), 'dummy')
 
-    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(
+      deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() }),
+    ).resolves.toBeUndefined()
 
     await expect(fs.access(path.join(workspace, `services/a/kustomization.yaml`))).rejects.toThrow()
     await expect(fs.access(path.join(workspace, `services/b/kustomization.yaml`))).rejects.toThrow()
@@ -90,7 +96,9 @@ describe('deleteFromServices', () => {
     await fs.writeFile(path.join(workspace, `services/a/kustomization.yaml`), 'dummy')
     await fs.writeFile(path.join(workspace, `services/b/kustomization.yaml`), 'dummy')
 
-    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices })).resolves.toBeUndefined()
+    await expect(
+      deleteFromServices({ workspace, patch, services: new Set(), excludeServices }),
+    ).resolves.toBeUndefined()
 
     await expect(fs.access(path.join(workspace, `services/a/kustomization.yaml`))).rejects.toThrow()
     await fs.access(path.join(workspace, `services/b/kustomization.yaml`))
@@ -98,6 +106,8 @@ describe('deleteFromServices', () => {
 
   test('if empty directory', async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'git-push-services-patch-'))
-    await expect(deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() })).resolves.toBeUndefined()
+    await expect(
+      deleteFromServices({ workspace, patch, services: new Set(), excludeServices: new Set() }),
+    ).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
I think it would be useful if I can specify services in `git-push-services-patch` action to apply patches only certain services, hdyt?

For the behavior when settings both `services` and `exclude-services`, I mimicked GitHub Actions' one about "paths" / "paths-ignore", see https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore.