### PR TITLE
Add `merged` output (open-backport-pull-request)

### DIFF
--- a/open-backport-pull-request/README.md
+++ b/open-backport-pull-request/README.md
@@ -38,7 +38,9 @@ See https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-
 ### Automatically merge the pull request
 
 You can set `merge-pull-request` to automatically merge the pull request.
-If the action could not merge due to a conflict or branch protection rule, it requests a review to the actor.
+
+You will get `merged` output to check if the pull request is merged.
+If this action could not merge due to a conflict or branch protection rule, it requests a review to the actor.
 
 ## Specification
 
@@ -54,8 +56,9 @@ If the action could not merge due to a conflict or branch protection rule, it re
 
 ### Outputs
 
-| Name               | Description                                |
-| ------------------ | ------------------------------------------ |
-| `pull-request-url` | URL of the opened Pull Request             |
-| `base-branch`      | The base branch of the opened Pull Request |
-| `head-branch`      | The head branch of the opened Pull Request |
+| Name               | Description                                   |
+| ------------------ | --------------------------------------------- |
+| `pull-request-url` | URL of the opened Pull Request                |
+| `base-branch`      | The base branch of the opened Pull Request    |
+| `head-branch`      | The head branch of the opened Pull Request    |
+| `merged`           | If the pull request is merged, returns `true` |

--- a/open-backport-pull-request/action.yaml
+++ b/open-backport-pull-request/action.yaml
@@ -26,6 +26,8 @@ outputs:
     description: The base branch of the opened Pull Request
   head-branch:
     description: The head branch of the opened Pull Request
+  merged:
+    description: If the pull request is merged, returns `true`
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/open-backport-pull-request/src/main.ts
+++ b/open-backport-pull-request/src/main.ts
@@ -2,13 +2,19 @@ import * as core from '@actions/core'
 import { run } from './run'
 
 const main = async (): Promise<void> => {
-  await run({
+  const outputs = await run({
     githubToken: core.getInput('github-token', { required: true }),
     headBranch: core.getInput('head-branch', { required: true }),
     baseBranch: core.getInput('base-branch', { required: true }),
     skipCI: core.getBooleanInput('skip-ci', { required: true }),
     mergePullRequest: core.getBooleanInput('merge-pull-request', { required: true }),
   })
+  if (outputs) {
+    core.setOutput('pull-request-url', outputs.pullRequestUrl)
+    core.setOutput('base-branch', outputs.baseBranch)
+    core.setOutput('head-branch', outputs.headBranch)
+    core.setOutput('merged', outputs.merged)
+  }
 }
 
 main().catch((e: Error) => {


### PR DESCRIPTION
When open-backport-pull-request action merged the pull request automatically, it would be nice if we can change the notification message.

This PR will add `merged` output to determine that.
