### PR TITLE
chore(delete-pull-request-namespaces) Fix jest issue

### DIFF
--- a/delete-pull-request-namespaces/jest.config.js
+++ b/delete-pull-request-namespaces/jest.config.js
@@ -1,5 +1,10 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
+  // preset: 'ts-jest/presets/js-with-babel-esm',
+  // https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1068342692
+  moduleNameMapper: {
+    '(.+)\\.js': '$1',
+  },
   clearMocks: true,
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],

--- a/delete-pull-request-namespaces/package.json
+++ b/delete-pull-request-namespaces/package.json
@@ -6,6 +6,7 @@
     "build": "ncc build --source-map --license licenses.txt src/main.ts",
     "test": "jest"
   },
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.10.1",
     "@actions/exec": "1.1.1",

--- a/delete-pull-request-namespaces/src/applications.ts
+++ b/delete-pull-request-namespaces/src/applications.ts
@@ -1,9 +1,9 @@
 import * as core from '@actions/core'
-import * as git from './git'
+import * as git from './git.js'
 import * as io from '@actions/io'
 import * as path from 'path'
 import { promises as fs } from 'fs'
-import { retryExponential } from './retry'
+import { retryExponential } from './retry.js'
 
 type DeleteNamespaceApplicationsOptions = {
   overlay: string

--- a/delete-pull-request-namespaces/src/main.ts
+++ b/delete-pull-request-namespaces/src/main.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import { run } from './run'
+import { run } from './run.js'
 
 const main = async (): Promise<void> => {
   await run({

--- a/delete-pull-request-namespaces/src/run.ts
+++ b/delete-pull-request-namespaces/src/run.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import { deleteNamespaceApplicationsWithRetry } from './applications'
-import { notifyDeletion } from './notify'
+import { deleteNamespaceApplicationsWithRetry } from './applications.js'
+import { notifyDeletion } from './notify.js'
 
 type Inputs = {
   overlay: string

--- a/delete-pull-request-namespaces/tests/applications.test.ts
+++ b/delete-pull-request-namespaces/tests/applications.test.ts
@@ -1,7 +1,7 @@
-import * as git from '../src/git'
+import * as git from '../src/git.js'
 import * as os from 'os'
 import * as path from 'path'
-import { deleteNamespaceApplicationsWithRetry } from '../src/applications'
+import { deleteNamespaceApplicationsWithRetry } from '../src/applications.js'
 import { promises as fs } from 'fs'
 
 jest.mock('../src/git')


### PR DESCRIPTION
- https://github.com/octokit/request-error.js/releases/tag/v6.0.0
  - CommonJS から ESM になった関係で一式壊れたようです
- `delete-pull-request-namespaces`  そのものを CommonJS から ESM へ切り替えて対応します
    - これであっているのかは自信がないです

Ref:
- https://github.com/quipper/monorepo-deploy-actions/pull/1354