### PR TITLE
Fix extractPullRequestNumber bug (cleanup-closed-pull-requests)

### DIFF
--- a/cleanup-closed-pull-requests/src/applications.ts
+++ b/cleanup-closed-pull-requests/src/applications.ts
@@ -126,12 +126,12 @@ const findApplications = async (cwd: string, opts: DeleteNamespaceApplicationsOp
   return applications
 }
 
-const extractPullRequestNumber = (filename: string, prefix: string, suffix = '.yaml'): number | undefined => {
-  if (!filename.startsWith(prefix) || !filename.endsWith(suffix)) {
+export const extractPullRequestNumber = (filename: string, prefix: string): number | undefined => {
+  if (!filename.startsWith(prefix)) {
     return
   }
   const withoutPrefix = filename.substring(prefix.length)
-  const withoutSuffix = withoutPrefix.substring(0, suffix.length)
+  const withoutSuffix = withoutPrefix.replace(/\..+$/, '')
   const n = Number.parseInt(withoutSuffix)
   if (Number.isSafeInteger(n)) {
     return n

--- a/cleanup-closed-pull-requests/tests/applications.test.ts
+++ b/cleanup-closed-pull-requests/tests/applications.test.ts
@@ -1,7 +1,7 @@
 import * as git from '../src/git.js'
 import * as os from 'os'
 import * as path from 'path'
-import { deleteNamespaceApplicationsWithRetry } from '../src/applications.js'
+import { deleteNamespaceApplicationsWithRetry, extractPullRequestNumber } from '../src/applications.js'
 import { promises as fs } from 'fs'
 
 jest.mock('../src/git')
@@ -114,3 +114,13 @@ const listFilenames = async (dir: string) =>
   (await fs.readdir(dir, { withFileTypes: true })).filter((e) => e.isFile()).map((e) => e.name)
 
 const dateMinutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60 * 1000)
+
+describe('extractPullRequestNumber', () => {
+  it('should extract pull request number', () => {
+    expect(extractPullRequestNumber('pr-1234567.yaml', 'pr-')).toEqual(1234567)
+  })
+
+  it('should return undefined if not matched', () => {
+    expect(extractPullRequestNumber('foo-123.yaml', 'pr-')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem to solve
cleanup-closed-pull-requests action always remove the pull requests > 99999. This will fix the bug of parsing pull request number.
