### PR TITLE
Add deprecation to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,12 @@
 
 This is a set of GitHub Actions to deploy microservices in a mono-repository (monorepo).
 
-## Motivation
-
-TODO
-
-## Concept
+## Design
 
 ### Structure of monorepo
 
-In Quipper, our monorepo contains a set of microservices with Kubernetes manifests, for example,
+Our monorepo contains a set of microservices with application code and Kubernetes manifests.
+Here is the directory structure.
 
 ```
 monorepo
@@ -81,18 +78,6 @@ Here are the definitions of words.
 | `service`                | name of microservice                    | `backend` or `frontend` |
 
 ### Destination repository
-
-We stores generated manifests into a repository.
-Argo CD syncs between the repository and cluster.
-
-main branch of the repository contains Application manifests.
-
-```
-destination-repository  (branch: main)
-└── ${source-repository-name}
-    └── ${overlay}
-        └── ${namespace}.yaml  (Application)
-```
 
 A namespace branch contains a set of generated manifest and Application manifest per a service.
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ For a typical namespace such as develop or production, it is deployed with the b
 
 ```mermaid
 graph LR
-  App[Application monorepo--develop]
   subgraph "generated-manifests"
     App --> AppService[Application develop--SERVICE] --> Resources
   end
+  App[Application monorepo--develop]
 ```
 
 For a pull request namespace, it is deployed with the below applications and [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a set of GitHub Actions to deploy microservices in a mono-repository (mo
 ### Structure of monorepo
 
 Our monorepo contains a set of microservices with application code and Kubernetes manifests.
-Here is the directory structure.
+Here is the example of directory structure.
 
 ```
 monorepo
@@ -56,26 +56,18 @@ monorepo
                 └── kustomization.yaml
 ```
 
+Here are the definitions of words.
+
+| Name                     | Description                                 | Example    |
+| ------------------------ | ------------------------------------------- | ---------- |
+| `source-repository-name` | Name of the source repository               | `monorepo` |
+| `overlay`                | Name of the overlay to build with Kustomize | `staging`  |
+| `namespace`              | Namespace to deploy into a cluster          | `pr-12345` |
+| `service`                | Name of a microservice                      | `backend`  |
+
 ### Structure of Argo CD Applications
 
 We adopt [App of Apps pattern of Argo CD](https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/) for deployment hierarchy.
-To deploy multiple microservices (which are built from an overlay) to a namespace, we creates the following applications into Argo CD:
-
-```
-${source-repository-name}  (Application)
-└── ${overlay}  (Application)
-    └── ${namespace}  (Application)
-        └── ${service}  (Application)
-```
-
-Here are the definitions of words.
-
-| Name                     | Description                             | Example                 |
-| ------------------------ | --------------------------------------- | ----------------------- |
-| `source-repository-name` | name of source repository               | `monorepo`              |
-| `overlay`                | name of overlay to build with Kustomize | `staging`               |
-| `namespace`              | namespace to deploy into a cluster      | `pr-12345`              |
-| `service`                | name of microservice                    | `backend` or `frontend` |
 
 ### Destination repository
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Here are the definitions of words.
 
 | Name                     | Description                                 | Example    |
 | ------------------------ | ------------------------------------------- | ---------- |
-| `source-repository-name` | Name of the source repository               | `monorepo` |
 | `overlay`                | Name of the overlay to build with Kustomize | `staging`  |
 | `namespace`              | Namespace to deploy into a cluster          | `pr-12345` |
 | `service`                | Name of a microservice                      | `backend`  |
@@ -69,7 +68,25 @@ Here are the definitions of words.
 
 We adopt [App of Apps pattern of Argo CD](https://argoproj.github.io/argo-cd/operator-manual/cluster-bootstrapping/) for deployment hierarchy.
 
-### Destination repository
+For a typical namespace such as develop or production, it is deployed with the below applications.
+
+```mermaid
+graph LR
+  App[Application monorepo--develop]
+  subgraph "generated-manifests"
+    App --> AppService[Application develop--SERVICE] --> Resources
+  end
+```
+
+For a pull request namespace, it is deployed with the below applications and [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/).
+
+```mermaid
+graph LR
+  subgraph "generated-manifests"
+    AppService[Application pr-NUMBER--SERVICE] --> Resources
+  end
+  AppSet[ApplicationSet monorepo--pr] --> AppPr[Application pr-NUMBER] --> AppService
+```
 
 A namespace branch contains a set of generated manifest and Application manifest per a service.
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ For a typical namespace such as develop or production, it is deployed with the b
 ```mermaid
 graph LR
   subgraph "generated-manifests"
-    App --> AppService[Application develop--SERVICE] --> Resources
+    AppService[Application develop--SERVICE] --> Resources
   end
-  App[Application monorepo--develop]
+  App[Application monorepo--develop] --> AppService
 ```
 
 For a pull request namespace, it is deployed with the below applications and [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/).

--- a/cleanup-closed-pull-requests/README.md
+++ b/cleanup-closed-pull-requests/README.md
@@ -1,3 +1,10 @@
+# :warning: DEPRECATED
+
+Use [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/) instead.
+This action will be removed in the future.
+
+---
+
 # cleanup-closed-pull-requests [![cleanup-closed-pull-requests](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/cleanup-closed-pull-requests.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/cleanup-closed-pull-requests.yaml)
 
 This is an action to delete the namespaces of closed pull requests.

--- a/delete-pull-request-namespaces/README.md
+++ b/delete-pull-request-namespaces/README.md
@@ -1,3 +1,10 @@
+# :warning: DEPRECATED
+
+Use [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/) instead.
+This action will be removed in the future.
+
+---
+
 # delete-pull-request-namespaces [![delete-pull-request-namespaces](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/delete-pull-request-namespaces.yaml/badge.svg)](https://github.com/quipper/monorepo-deploy-actions/actions/workflows/delete-pull-request-namespaces.yaml)
 
 This is an action to delete pull request namespaces.

--- a/git-push-namespace/README.md
+++ b/git-push-namespace/README.md
@@ -1,3 +1,10 @@
+# :warning: DEPRECATED
+
+Use [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/) instead.
+This action will be removed in the future.
+
+---
+
 # git-push-namespace
 
 This is an action to push an Argo CD `Application` manifest to deploy a namespace.


### PR DESCRIPTION
We have migrated our pull request deployment to [the pull request generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/). This adds the deprecation notice to the actions.

## Internal issue
- https://github.com/quipper/quipper/issues/34530