### PR TITLE
Support ExternalSecret (resolve-aws-secret-version)

### DIFF
--- a/resolve-aws-secret-version/README.md
+++ b/resolve-aws-secret-version/README.md
@@ -1,7 +1,10 @@
 # resolve-aws-secret-version
 
 This is an action to resolve the secret versions of manifests.
-It is designed for https://github.com/mumoshu/aws-secret-operator.
+It supports the following operators:
+
+- `AWSSecret` resource of https://github.com/mumoshu/aws-secret-operator
+- `ExternalSecret` resource of https://github.com/external-secrets/external-secrets
 
 ## Inputs
 
@@ -43,24 +46,25 @@ spec:
             - secretRef:
                 name: microservice-${AWS_SECRETS_MANAGER_VERSION_ID}
 ---
-apiVersion: mumoshu.github.io/v1alpha1
-kind: AWSSecret
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
 metadata:
   name: microservice-${AWS_SECRETS_MANAGER_VERSION_ID}
 spec:
-  stringDataFrom:
-    secretsManagerSecretRef:
-      secretId: microservice/develop
-      versionId: ${AWS_SECRETS_MANAGER_VERSION_ID}
+  dataFrom:
+    - extract:
+        key: microservice/develop
+        version: uuid/${AWS_SECRETS_MANAGER_VERSION_ID}
 ```
 
-This action replaces a placeholder in `versionId` field with the current version ID.
-In this example, it replaces `${AWS_SECRETS_MANAGER_VERSION_ID}` with the current one.
+This action replaces a placeholder in `version` field with the current version ID.
+In this example, it replaces `${AWS_SECRETS_MANAGER_VERSION_ID}` with the current version ID.
 
-Here are some rules:
+This action replaces the placeholders by the following rules:
 
-- If a manifest does not contain any `AWSSecret`, do nothing
-- If `versionId` field is not placeholder in form of `${...}`, it is ignored
+- If a manifest does not contain any `ExternalSecret` or `AWSSecret`, do nothing.
+- It replaces the placeholder if `version` field of `ExternalSecret` has a placeholder in form of `uuid/${...}`.
+- It replaces the placeholder if `versionId` field of `AWSSecret` has a placeholder in form of `${...}`.
 
 Finally this action writes the below manifest:
 
@@ -78,15 +82,15 @@ spec:
             - secretRef:
                 name: microservice-c7ea50c5-b2be-4970-bf90-2237bef3b4cf
 ---
-apiVersion: mumoshu.github.io/v1alpha1
-kind: AWSSecret
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
 metadata:
   name: microservice-c7ea50c5-b2be-4970-bf90-2237bef3b4cf
 spec:
-  stringDataFrom:
-    secretsManagerSecretRef:
-      secretId: microservice/develop
-      versionId: c7ea50c5-b2be-4970-bf90-2237bef3b4cf
+  dataFrom:
+    - extract:
+        key: microservice/develop
+        version: uuid/c7ea50c5-b2be-4970-bf90-2237bef3b4cf
 ```
 
 This action accepts multi-line paths.

--- a/resolve-aws-secret-version/src/kubernetes.ts
+++ b/resolve-aws-secret-version/src/kubernetes.ts
@@ -22,22 +22,54 @@ export type KubernetesAWSSecret = KubernetesObject & {
 }
 
 export function assertKubernetesAWSSecret(a: KubernetesObject): asserts a is KubernetesAWSSecret {
-  assertHasField(a, 'metadata')
-  assertHasField(a.metadata, 'name')
+  assertHasField(a, 'AWSSecret', 'metadata')
+  assertHasField(a.metadata, 'AWSSecret', 'name')
   assert(typeof a.metadata.name === 'string', `metadata.name must be a string`)
 
-  assertHasField(a, 'spec')
-  assertHasField(a.spec, 'stringDataFrom')
-  assertHasField(a.spec.stringDataFrom, 'secretsManagerSecretRef')
+  assertHasField(a, 'AWSSecret', 'spec')
+  assertHasField(a.spec, 'AWSSecret', 'stringDataFrom')
+  assertHasField(a.spec.stringDataFrom, 'AWSSecret', 'secretsManagerSecretRef')
 
-  assertHasField(a.spec.stringDataFrom.secretsManagerSecretRef, 'secretId')
+  assertHasField(a.spec.stringDataFrom.secretsManagerSecretRef, 'AWSSecret', 'secretId')
   assert(typeof a.spec.stringDataFrom.secretsManagerSecretRef.secretId === 'string')
 
-  assertHasField(a.spec.stringDataFrom.secretsManagerSecretRef, 'versionId')
+  assertHasField(a.spec.stringDataFrom.secretsManagerSecretRef, 'AWSSecret', 'versionId')
   assert(typeof a.spec.stringDataFrom.secretsManagerSecretRef.versionId === 'string')
 }
 
-function assertHasField<K extends string>(o: unknown, key: K): asserts o is Record<K, unknown> {
+export type KubernetesExternalSecret = KubernetesObject & {
+  metadata: {
+    name: string
+  }
+  spec: {
+    dataFrom: {
+      extract: {
+        key: string
+        version: string
+      }
+    }[]
+  }
+}
+
+export function assertKubernetesExternalSecret(a: KubernetesObject): asserts a is KubernetesExternalSecret {
+  assertHasField(a, 'ExternalSecret', 'metadata')
+  assertHasField(a.metadata, 'ExternalSecret', 'name')
+  assert(typeof a.metadata.name === 'string', `metadata.name must be a string`)
+
+  assertHasField(a, 'ExternalSecret', 'spec')
+  assertHasField(a.spec, 'ExternalSecret', 'dataFrom')
+  assert(Array.isArray(a.spec.dataFrom), `spec.dataFrom.extract must be an array`)
+
+  for (const dataFrom of a.spec.dataFrom) {
+    assertHasField(dataFrom, 'ExternalSecret', 'extract')
+    assertHasField(dataFrom.extract, 'ExternalSecret', 'key')
+    assert(typeof dataFrom.extract.key === 'string', `spec.dataFrom.extract.key must be a string`)
+    assertHasField(dataFrom.extract, 'ExternalSecret', 'version')
+    assert(typeof dataFrom.extract.version === 'string', `spec.dataFrom.extract.version must be a string`)
+  }
+}
+
+function assertHasField<K extends string>(o: unknown, kind: string, key: K): asserts o is Record<K, unknown> {
   assert(typeof o === 'object' && o !== null, `must be an object`)
-  assert(key in o, `AWSSecret must have ${key} field`)
+  assert(key in o, `${kind} must have ${key} field`)
 }

--- a/resolve-aws-secret-version/tests/fixtures/expected-with-externalsecret-placeholder.yaml
+++ b/resolve-aws-secret-version/tests/fixtures/expected-with-externalsecret-placeholder.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: echoserver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: echoserver
+    spec:
+      containers:
+        - image: ${DOCKER_IMAGE}
+          name: echoserver
+          envFrom:
+            - secretRef:
+                # this should be replaced
+                name: my-service-c7ea50c5-b2be-4970-bf90-2237bef3b4cf
+        - image: envoyproxy/envoy
+          name: envoy
+          envFrom:
+            - secretRef:
+                # this should not be replaced
+                name: envoy-${AWS_SECRETS_MANAGER_VERSION_ID_ENVOY}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: my-service-c7ea50c5-b2be-4970-bf90-2237bef3b4cf
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: my-service/develop
+        version: uuid/c7ea50c5-b2be-4970-bf90-2237bef3b4cf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: echoserver
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: docker-hub
+spec:
+  target:
+    template:
+      type: kubernetes.io/dockerconfigjson
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: docker-hub-credentials
+        version: uuid/2eb0efcf-14ee-4526-b8ce-971ec82b3aca

--- a/resolve-aws-secret-version/tests/fixtures/input-with-externalsecret-placeholder.yaml
+++ b/resolve-aws-secret-version/tests/fixtures/input-with-externalsecret-placeholder.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: echoserver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: echoserver
+    spec:
+      containers:
+        - image: ${DOCKER_IMAGE}
+          name: echoserver
+          envFrom:
+            - secretRef:
+                # this should be replaced
+                name: my-service-${AWS_SECRETS_MANAGER_VERSION_ID}
+        - image: envoyproxy/envoy
+          name: envoy
+          envFrom:
+            - secretRef:
+                # this should not be replaced
+                name: envoy-${AWS_SECRETS_MANAGER_VERSION_ID_ENVOY}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: my-service-${AWS_SECRETS_MANAGER_VERSION_ID}
+spec:
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: my-service/develop
+        version: uuid/${AWS_SECRETS_MANAGER_VERSION_ID}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/name: echoserver
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: docker-hub
+spec:
+  target:
+    template:
+      type: kubernetes.io/dockerconfigjson
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: docker-hub-credentials
+        version: uuid/2eb0efcf-14ee-4526-b8ce-971ec82b3aca

--- a/resolve-aws-secret-version/tests/resolve.test.ts
+++ b/resolve-aws-secret-version/tests/resolve.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs'
 import * as os from 'os'
 import { replaceSecretVersionIds, updateManifest } from '../src/resolve.js'
 
-it('replaces the placeholder with the current version id', async () => {
+it('replaces the placeholder of AWSSecret with the current version id', async () => {
   const manager = { getCurrentVersionId: jest.fn() }
   manager.getCurrentVersionId.mockResolvedValue('c7ea50c5-b2be-4970-bf90-2237bef3b4cf')
 
@@ -13,6 +13,20 @@ it('replaces the placeholder with the current version id', async () => {
   await updateManifest(fixtureFile, manager)
   const output = (await fs.readFile(fixtureFile)).toString()
   const expected = (await fs.readFile(`${__dirname}/fixtures/expected-with-awssecret-placeholder.yaml`)).toString()
+  expect(output).toBe(expected)
+})
+
+it('replaces the placeholder of ExternalSecret with the current version id', async () => {
+  const manager = { getCurrentVersionId: jest.fn() }
+  manager.getCurrentVersionId.mockResolvedValue('c7ea50c5-b2be-4970-bf90-2237bef3b4cf')
+
+  const tempdir = await fs.mkdtemp(`${os.tmpdir()}/resolve-aws-secret-version-action-`)
+  const fixtureFile = `${tempdir}/fixture.yaml`
+  await fs.copyFile(`${__dirname}/fixtures/input-with-externalsecret-placeholder.yaml`, fixtureFile)
+
+  await updateManifest(fixtureFile, manager)
+  const output = (await fs.readFile(fixtureFile)).toString()
+  const expected = (await fs.readFile(`${__dirname}/fixtures/expected-with-externalsecret-placeholder.yaml`)).toString()
   expect(output).toBe(expected)
 })
 

--- a/resolve-aws-secret-version/tests/run.test.ts
+++ b/resolve-aws-secret-version/tests/run.test.ts
@@ -6,18 +6,27 @@ import { run } from '../src/run.js'
 jest.mock('../src/awsSecretsManager')
 const getCurrentVersionId = awsSecretsManager.getCurrentVersionId as jest.Mock
 
-test('run', async () => {
+it('replaces the placeholders of secrets', async () => {
   getCurrentVersionId.mockResolvedValue('c7ea50c5-b2be-4970-bf90-2237bef3b4cf')
 
   const tempdir = await fs.mkdtemp(`${os.tmpdir()}/resolve-aws-secret-version-action-`)
-  const fixtureFile = `${tempdir}/fixture.yaml`
-  await fs.copyFile(`${__dirname}/fixtures/input-with-awssecret-placeholder.yaml`, fixtureFile)
+  await fs.copyFile(
+    `${__dirname}/fixtures/input-with-awssecret-placeholder.yaml`,
+    `${tempdir}/input-with-awssecret-placeholder.yaml`,
+  )
+  await fs.copyFile(
+    `${__dirname}/fixtures/input-with-externalsecret-placeholder.yaml`,
+    `${tempdir}/input-with-externalsecret-placeholder.yaml`,
+  )
 
   await run({
     manifests: `${tempdir}/**/*.yaml`,
   })
 
-  const output = (await fs.readFile(fixtureFile)).toString()
-  const expected = (await fs.readFile(`${__dirname}/fixtures/expected-with-awssecret-placeholder.yaml`)).toString()
-  expect(output).toBe(expected)
+  expect(await fs.readFile(`${tempdir}/input-with-awssecret-placeholder.yaml`, 'utf-8')).toBe(
+    await fs.readFile(`${__dirname}/fixtures/expected-with-awssecret-placeholder.yaml`, 'utf-8'),
+  )
+  expect(await fs.readFile(`${tempdir}/input-with-externalsecret-placeholder.yaml`, 'utf-8')).toBe(
+    await fs.readFile(`${__dirname}/fixtures/expected-with-externalsecret-placeholder.yaml`, 'utf-8'),
+  )
 })


### PR DESCRIPTION
This supports the `ExternalSecret` resource of https://github.com/external-secrets/external-secrets.

## Internal issue
- https://github.com/quipper/quipper/issues/34565
