### PR TITLE
Fix current sha (bootstrap-pull-request)

### DIFF
--- a/bootstrap-pull-request/action.yaml
+++ b/bootstrap-pull-request/action.yaml
@@ -25,6 +25,9 @@ inputs:
   substitute-variables:
     description: Pairs of key=value to substitute the prebuilt manifests (multiline)
     required: false
+  current-head-sha:
+    description: SHA of current head commit (For internal use)
+    default: ${{ github.event.pull_request.head.sha || github.sha }}
 
 runs:
   using: 'node20'

--- a/bootstrap-pull-request/src/main.ts
+++ b/bootstrap-pull-request/src/main.ts
@@ -10,6 +10,7 @@ const main = async (): Promise<void> => {
     destinationRepositoryToken: core.getInput('destination-repository-token', { required: true }),
     namespaceManifest: core.getInput('namespace-manifest') || undefined,
     substituteVariables: core.getMultilineInput('substitute-variables'),
+    currentHeadSha: core.getInput('current-head-sha', { required: true }),
   })
 }
 

--- a/bootstrap-pull-request/src/run.ts
+++ b/bootstrap-pull-request/src/run.ts
@@ -13,6 +13,7 @@ type Inputs = {
   destinationRepositoryToken: string
   namespaceManifest: string | undefined
   substituteVariables: string[]
+  currentHeadSha: string
 }
 
 export const run = async (inputs: Inputs): Promise<void> =>
@@ -31,7 +32,7 @@ const bootstrapNamespace = async (inputs: Inputs): Promise<void | Error> => {
   const [, sourceRepositoryName] = inputs.sourceRepository.split('/')
 
   await syncServicesFromPrebuilt({
-    currentSha: github.context.sha,
+    currentSha: inputs.currentHeadSha,
     overlay: inputs.overlay,
     namespace: inputs.namespace,
     sourceRepositoryName,


### PR DESCRIPTION
Fix the bug of https://github.com/quipper/monorepo-deploy-actions/pull/1763.

bootstrap-pull-request overwrites an application even if `github.head-sha` annotation refers the current head.
