### PR TITLE
Add `github.head-ref` annotation and job summary (bootstrap-pull-request)

### DIFF
--- a/.github/workflows/bootstrap-pull-request.yaml
+++ b/.github/workflows/bootstrap-pull-request.yaml
@@ -56,10 +56,7 @@ jobs:
       - name: Set up an prebuilt branch
         working-directory: prebuilt-branch
         run: |
-          mkdir -vp services/a
-          mkdir -vp services/b
-          touch services/a/generated.yaml
-          touch services/b/generated.yaml
+          cp -av "$GITHUB_WORKSPACE/bootstrap-pull-request/tests/fixtures/prebuilt/." .
           git add .
           git commit -m "Add prebuilt branch for e2e-test of ${GITHUB_REF}"
           git push origin "HEAD:refs/heads/prebuilt/monorepo-deploy-actions/overlay-${{ github.run_id }}"

--- a/bootstrap-pull-request/src/prebuilt.ts
+++ b/bootstrap-pull-request/src/prebuilt.ts
@@ -48,9 +48,9 @@ const deleteOutdatedApplicationManifest = async (
   applicationManifestPath: string,
   currentHeadSha: string,
 ): Promise<Service | undefined> => {
-  const existingApplication = await parseApplicationManifest(applicationManifestPath)
-  if (existingApplication instanceof Error) {
-    const error: Error = existingApplication
+  const application = await parseApplicationManifest(applicationManifestPath)
+  if (application instanceof Error) {
+    const error: Error = application
     core.info(`Deleting the invalid application manifest: ${applicationManifestPath}: ${String(error)}`)
     await io.rmRF(applicationManifestPath)
     return
@@ -58,25 +58,25 @@ const deleteOutdatedApplicationManifest = async (
 
   // bootstrap-pull-request action needs to be run after git-push-service action.
   // See https://github.com/quipper/monorepo-deploy-actions/pull/1763 for the details.
-  if (existingApplication.metadata.annotations['github.action'] === 'git-push-service') {
-    const service = path.basename(existingApplication.spec.source.path)
-    if (existingApplication.metadata.annotations['github.head-sha'] === currentHeadSha) {
+  if (application.metadata.annotations['github.action'] === 'git-push-service') {
+    const service = path.basename(application.spec.source.path)
+    if (application.metadata.annotations['github.head-sha'] === currentHeadSha) {
       core.info(`Preserving the application manifest: ${applicationManifestPath}`)
       return {
         service,
-        headRef: existingApplication.metadata.annotations['github.head-ref'],
-        headSha: existingApplication.metadata.annotations['github.head-sha'],
+        headRef: application.metadata.annotations['github.head-ref'],
+        headSha: application.metadata.annotations['github.head-sha'],
       }
     }
     // For the backward compatibility.
     // Before https://github.com/quipper/monorepo-deploy-actions/pull/1768, the head SHA was not recorded.
     // When this action is called for an old pull request, we assume that the application manifest was pushed on the current commit.
-    if (existingApplication.metadata.annotations['github.head-sha'] === undefined) {
+    if (application.metadata.annotations['github.head-sha'] === undefined) {
       core.info(`Preserving the application manifest: ${applicationManifestPath}`)
       return {
         service,
-        headRef: existingApplication.metadata.annotations['github.head-ref'],
-        headSha: existingApplication.metadata.annotations['github.head-sha'],
+        headRef: application.metadata.annotations['github.head-ref'],
+        headSha: application.metadata.annotations['github.head-sha'],
       }
     }
   }

--- a/bootstrap-pull-request/src/run.ts
+++ b/bootstrap-pull-request/src/run.ts
@@ -30,7 +30,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
       ],
       ...services.map((service) => [
         service.service,
-        `[${service.headRef}@${service.headSha}](${github.context.serverUrl}/${inputs.sourceRepository}/commit/${service.headSha})`,
+        `<a href="${github.context.serverUrl}/${inputs.sourceRepository}/commit/${service.headSha}">${service.headRef}@${service.headSha}</a>`,
       ]),
     ])
   }

--- a/bootstrap-pull-request/tests/fixtures/prebuilt/applications/prebuilt--a.yaml
+++ b/bootstrap-pull-request/tests/fixtures/prebuilt/applications/prebuilt--a.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    github.head-ref: refs/heads/main
+    github.head-ref: main
     github.head-sha: main-branch-sha
     github.action: git-push-service
 spec:

--- a/bootstrap-pull-request/tests/fixtures/prebuilt/applications/prebuilt--b.yaml
+++ b/bootstrap-pull-request/tests/fixtures/prebuilt/applications/prebuilt--b.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    github.head-ref: refs/heads/main
+    github.head-ref: main
     github.head-sha: main-branch-sha
     github.action: git-push-service
 spec:


### PR DESCRIPTION
## Changes
- Add `github.head-ref` annotation to a generated Application manifest
- Show the job summary

It helps our troubleshooting.

### Before
bootstrap-pull-request action writes the below manifest.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    github.action: bootstrap-pull-request
    github.head-sha: 0123456789abcdef
```

### After
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    github.action: bootstrap-pull-request
    github.head-ref: develop # <-- ADD
    github.head-sha: 0123456789abcdef
```

This change also adds the job summary, e.g., https://github.com/quipper/monorepo-deploy-actions/actions/runs/13005870920

<img width="850" alt="image" src="https://github.com/user-attachments/assets/21c12197-7a5a-455b-afa4-ac63abc5d493" />

