### PR TITLE
Fix current-head-ref is not set

### DIFF
--- a/git-push-service/action.yaml
+++ b/git-push-service/action.yaml
@@ -33,7 +33,7 @@ inputs:
     default: ${{ github.token }}
   current-head-ref:
     description: Ref of current head branch (For internal use)
-    default: ${{ github.head_ref }}
+    default: ${{ github.event.pull_request.head.ref || github.ref_name }}
   current-head-sha:
     description: SHA of current head commit (For internal use)
     default: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Fix the error of https://github.com/quipper/monorepo-deploy-actions/actions/runs/13022760949/job/36326587934