### PR TITLE
Improve traceability (bootstrap-pull-request)

### DIFF
--- a/bootstrap-pull-request/README.md
+++ b/bootstrap-pull-request/README.md
@@ -6,11 +6,12 @@ When a pull request is created or updated, this action copies the service manife
 ```mermaid
 graph LR
   subgraph Source repository
-    SourceNamespaceManifest[Namespace manifest]
+    Source[Source]
   end
   subgraph Destination repository
     subgraph Prebuilt branch
-      PrebuiltServiceManifest[Service manifest]
+      PrebuiltApplicationManifest[Application manifest]
+      Source --Build--> PrebuiltServiceManifest[Service manifest]
     end
     subgraph Namespace branch
       ApplicationManifest[Application manifest]
@@ -18,8 +19,7 @@ graph LR
       NamespaceManifest[Namespace manifest]
     end
   end
-  PrebuiltServiceManifest --Copy--> ServiceManifest
-  SourceNamespaceManifest --Copy--> NamespaceManifest
+  PrebuiltServiceManifest --Build--> ServiceManifest
 ```
 
 ## Getting Started

--- a/bootstrap-pull-request/action.yaml
+++ b/bootstrap-pull-request/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: SHA of current head commit (For internal use)
     default: ${{ github.event.pull_request.head.sha || github.sha }}
 
+outputs:
+  services:
+    description: JSON string of services. See prebuilt.ts for the JSON schema
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/bootstrap-pull-request/src/main.ts
+++ b/bootstrap-pull-request/src/main.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import { run } from './run.js'
 
 const main = async (): Promise<void> => {
-  await run({
+  const outputs = await run({
     overlay: core.getInput('overlay', { required: true }),
     namespace: core.getInput('namespace', { required: true }),
     sourceRepository: core.getInput('source-repository', { required: true }),
@@ -12,6 +12,7 @@ const main = async (): Promise<void> => {
     substituteVariables: core.getMultilineInput('substitute-variables'),
     currentHeadSha: core.getInput('current-head-sha', { required: true }),
   })
+  core.setOutput('services', JSON.stringify(outputs.services))
 }
 
 main().catch((e: Error) => {

--- a/bootstrap-pull-request/tests/prebuilt.test.ts
+++ b/bootstrap-pull-request/tests/prebuilt.test.ts
@@ -1,7 +1,7 @@
 import * as os from 'os'
 import * as path from 'path'
 import { promises as fs } from 'fs'
-import { syncServicesFromPrebuilt } from '../src/prebuilt.js'
+import { Service, syncServicesFromPrebuilt } from '../src/prebuilt.js'
 
 const readContent = async (filename: string) => await fs.readFile(filename, 'utf-8')
 
@@ -17,14 +17,31 @@ describe('syncServicesFromPrebuilt', () => {
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
       destinationRepository: 'octocat/destination-repository',
+      prebuiltBranch: 'prebuilt/source-repository/pr',
       prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
       namespaceDirectory,
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
-    expect(services).toStrictEqual([
-      { service: 'a', headRef: 'main', headSha: 'main-branch-sha' },
-      { service: 'b', headRef: 'main', headSha: 'main-branch-sha' },
+    expect(services).toStrictEqual<Service[]>([
+      {
+        service: 'a',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
+      {
+        service: 'b',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
     ])
     expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
@@ -46,14 +63,31 @@ describe('syncServicesFromPrebuilt', () => {
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
       destinationRepository: 'octocat/destination-repository',
+      prebuiltBranch: 'prebuilt/source-repository/pr',
       prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
       namespaceDirectory,
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
-    expect(services).toStrictEqual([
-      { service: 'a', headRef: 'main', headSha: 'main-branch-sha' },
-      { service: 'b', headRef: 'main', headSha: 'main-branch-sha' },
+    expect(services).toStrictEqual<Service[]>([
+      {
+        service: 'a',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
+      {
+        service: 'b',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
     ])
     expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
@@ -75,14 +109,23 @@ describe('syncServicesFromPrebuilt', () => {
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
       destinationRepository: 'octocat/destination-repository',
+      prebuiltBranch: 'prebuilt/source-repository/pr',
       prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
       namespaceDirectory,
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
-    expect(services).toStrictEqual([
-      { service: 'a', headRef: 'topic-branch', headSha: 'current-sha' },
-      { service: 'b', headRef: 'main', headSha: 'main-branch-sha' },
+    expect(services).toStrictEqual<Service[]>([
+      { service: 'a', builtFrom: { pullRequest: { headRef: 'topic-branch', headSha: 'current-sha' } } },
+      {
+        service: 'b',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
     ])
     expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(
@@ -104,14 +147,31 @@ describe('syncServicesFromPrebuilt', () => {
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
       destinationRepository: 'octocat/destination-repository',
+      prebuiltBranch: 'prebuilt/source-repository/pr',
       prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
       namespaceDirectory,
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
-    expect(services).toStrictEqual([
-      { service: 'a', headRef: 'main', headSha: 'main-branch-sha' },
-      { service: 'b', headRef: 'main', headSha: 'main-branch-sha' },
+    expect(services).toStrictEqual<Service[]>([
+      {
+        service: 'a',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
+      {
+        service: 'b',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
     ])
     expect(await fs.readdir(`${namespaceDirectory}/applications`, { recursive: true })).toStrictEqual([
       'pr-123--a.yaml',
@@ -135,14 +195,23 @@ describe('syncServicesFromPrebuilt', () => {
       namespace: 'pr-123',
       sourceRepositoryName: 'source-repository',
       destinationRepository: 'octocat/destination-repository',
+      prebuiltBranch: 'prebuilt/source-repository/pr',
       prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
       namespaceDirectory,
       substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
     })
 
-    expect(services).toStrictEqual([
-      { service: 'a', headRef: undefined, headSha: undefined },
-      { service: 'b', headRef: 'main', headSha: 'main-branch-sha' },
+    expect(services).toStrictEqual<Service[]>([
+      { service: 'a', builtFrom: { pullRequest: { headRef: undefined, headSha: undefined } } },
+      {
+        service: 'b',
+        builtFrom: {
+          prebuilt: {
+            prebuiltBranch: 'prebuilt/source-repository/pr',
+            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
+          },
+        },
+      },
     ])
     expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationPushedWithoutSha)
@@ -164,6 +233,7 @@ metadata:
     github.action: bootstrap-pull-request
     github.head-ref: main
     github.head-sha: main-branch-sha
+    built-from-prebuilt-branch: prebuilt/source-repository/pr
 spec:
   project: source-repository
   source:
@@ -268,6 +338,7 @@ metadata:
     github.action: bootstrap-pull-request
     github.head-ref: main
     github.head-sha: main-branch-sha
+    built-from-prebuilt-branch: prebuilt/source-repository/pr
 spec:
   project: source-repository
   source:


### PR DESCRIPTION
問題が起きた場合に以下を追跡できるようにします。

- サービスのマニフェストがビルドされたブランチやコミット
- サービスが pull request からビルドされた、もしくは、prebuilt からビルドされた

概念図：

```mermaid
graph LR
  subgraph Source repository
    Source[Source]
  end
  subgraph Destination repository
    subgraph Prebuilt branch
      PrebuiltApplicationManifest[Application manifest]
      Source --Build--> PrebuiltServiceManifest[Service manifest]
    end
    subgraph Namespace branch
      ApplicationManifest[Application manifest]
      ServiceManifest[Service manifest]
      NamespaceManifest[Namespace manifest]
    end
  end
  PrebuiltServiceManifest --Build--> ServiceManifest
```

## Test
https://github.com/quipper/monorepo-deploy-actions/actions/runs/13104477161?pr=1807

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/f33379c0-c5f2-4111-bcdf-83e720662333" />

## Issue
- https://github.com/quipper/quipper/issues/34634
