### PR TITLE
Remove @octokit/request-error

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,6 @@
       // https://github.com/quipper/monorepo-deploy-actions/pull/1362
       "matchPackageNames": [
         "@octokit/core",
-        "@octokit/request-error",
         "@octokit/plugin-retry",
       ],
       "enabled": false,

--- a/create-deploy-pull-request/package.json
+++ b/create-deploy-pull-request/package.json
@@ -9,8 +9,7 @@
   },
   "dependencies": {
     "@actions/core": "1.11.1",
-    "@actions/github": "6.0.0",
-    "@octokit/request-error": "5.0.1"
+    "@actions/github": "6.0.0"
   },
   "devDependencies": {
     "msw": "2.7.3"

--- a/create-deploy-pull-request/src/branch.ts
+++ b/create-deploy-pull-request/src/branch.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core'
 import { GitHub } from '@actions/github/lib/utils'
-import { RequestError } from '@octokit/request-error'
 
 type Octokit = InstanceType<typeof GitHub>
 
@@ -15,7 +14,7 @@ export const checkIfBranchExists = async (octokit: Octokit, options: CheckIfBran
     await octokit.rest.repos.getBranch(options)
     return true
   } catch (error) {
-    if (error instanceof RequestError && error.status === 404) {
+    if (isRequestError(error) && error.status === 404) {
       return false
     }
     throw error
@@ -46,3 +45,8 @@ export const createBranch = async (octokit: Octokit, options: CreateUpdateBranch
     sha: fromBranch.commit.sha,
   })
 }
+
+type RequestError = Error & { status: number }
+
+const isRequestError = (error: unknown): error is RequestError =>
+  error instanceof Error && 'status' in error && typeof error.status === 'number'

--- a/environment-matrix/package.json
+++ b/environment-matrix/package.json
@@ -11,7 +11,6 @@
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.0",
     "@octokit/plugin-retry": "6.0.1",
-    "@octokit/request-error": "5.0.1",
     "ajv": "8.17.1",
     "js-yaml": "4.1.0",
     "minimatch": "10.0.1"

--- a/environment-matrix/src/deployment.ts
+++ b/environment-matrix/src/deployment.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { Environment } from './rule.js'
-import { RequestError } from '@octokit/request-error'
 import { Octokit, assertPullRequestPayload } from './github.js'
 import assert from 'assert'
 
@@ -58,7 +57,7 @@ const createDeployment = async (
         deployment_id: deployment.id,
       })
     } catch (error) {
-      if (error instanceof RequestError) {
+      if (isRequestError(error)) {
         core.warning(`Could not delete the old deployment ${deployment.url}: ${error.status} ${error.message}`)
         continue
       }
@@ -107,3 +106,8 @@ const getDeploymentRef = (context: Context): string => {
   }
   return context.ref
 }
+
+type RequestError = Error & { status: number }
+
+const isRequestError = (error: unknown): error is RequestError =>
+  error instanceof Error && 'status' in error && typeof error.status === 'number'

--- a/git-push-service/package.json
+++ b/git-push-service/package.json
@@ -13,7 +13,6 @@
     "@actions/github": "6.0.0",
     "@actions/glob": "0.5.0",
     "@actions/io": "1.1.3",
-    "@octokit/request-error": "5.0.1",
     "js-yaml": "4.1.0"
   },
   "devDependencies": {

--- a/git-push-service/src/retry.ts
+++ b/git-push-service/src/retry.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import { RequestError } from '@octokit/request-error'
 
 type RetrySpec = {
   maxAttempts: number
@@ -28,9 +27,14 @@ export const catchHttpStatus = async <T>(status: number, f: () => Promise<T>): P
   try {
     return await f()
   } catch (e) {
-    if (e instanceof RequestError && e.status === status) {
+    if (isRequestError(e) && e.status === status) {
       return e // retry
     }
     throw e
   }
 }
+
+type RequestError = Error & { status: number }
+
+const isRequestError = (error: unknown): error is RequestError =>
+  error instanceof Error && 'status' in error && typeof error.status === 'number'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       '@actions/github':
         specifier: 6.0.0
         version: 6.0.0
-      '@octokit/request-error':
-        specifier: 5.0.1
-        version: 5.0.1
     devDependencies:
       msw:
         specifier: 2.7.3
@@ -103,9 +100,6 @@ importers:
       '@octokit/plugin-retry':
         specifier: 6.0.1
         version: 6.0.1(@octokit/core@5.1.0)
-      '@octokit/request-error':
-        specifier: 5.0.1
-        version: 5.0.1
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -159,9 +153,6 @@ importers:
       '@actions/io':
         specifier: 1.1.3
         version: 1.1.3
-      '@octokit/request-error':
-        specifier: 5.0.1
-        version: 5.0.1
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0


### PR DESCRIPTION
After updating pnpm to v10.5.0, the test is failing.
https://github.com/quipper/monorepo-deploy-actions/actions/runs/13535185916/job/37825431388?pr=1842

```
  ● should create base branch if not exist

    HttpError:

      13 | export const checkIfBranchExists = async (octokit: Octokit, options: CheckIfBranchExistsOptions): Promise<boolean> => {
      14 |   try {
    > 15 |     await octokit.rest.repos.getBranch(options)
         |     ^
      16 |     return true
      17 |   } catch (error) {
      18 |     if (error instanceof RequestError && error.status === 404) {

      at ../node_modules/.pnpm/@octokit+request@8.4.1/node_modules/@octokit/request/dist-node/index.js:125:21
      at checkIfBranchExists (src/branch.ts:15:5)
      at run (src/run.ts:29:28)
```

I think `instanceof` does not work after the update. Let me replace it.

## Related PR
- https://github.com/quipper/monorepo-deploy-actions/pull/1842
