### PR TITLE
Change rules schema (environment-matrix)

### DIFF
--- a/.github/workflows/environment-matrix.yaml
+++ b/.github/workflows/environment-matrix.yaml
@@ -55,13 +55,15 @@ jobs:
                 base: '**'
                 head: '**'
               environments:
-                - overlay: pr
-                  namespace: pr-${{ github.event.pull_request.number }}
+                - outputs:
+                    overlay: pr
+                    namespace: pr-${{ github.event.pull_request.number }}
             - push:
                 ref: refs/heads/main
               environments:
-                - overlay: development
-                  namespace: development
+                - outputs:
+                    overlay: development
+                    namespace: development
 
   e2e-test-matrix:
     needs: e2e-test

--- a/.github/workflows/environment-matrix.yaml
+++ b/.github/workflows/environment-matrix.yaml
@@ -49,13 +49,14 @@ jobs:
       - uses: ./environment-matrix
         id: environment-matrix
         with:
-          service: example
           rules: |
             - pull_request:
                 base: '**'
                 head: '**'
               environments:
-                - outputs:
+                - github-deployment:
+                    environment: pr-${{ github.event.pull_request.number }}/example
+                  outputs:
                     overlay: pr
                     namespace: pr-${{ github.event.pull_request.number }}
             - push:

--- a/environment-matrix/action.yaml
+++ b/environment-matrix/action.yaml
@@ -4,9 +4,6 @@ inputs:
   rules:
     description: YAML string of rules
     required: true
-  service:
-    description: Name of service. If set, create GitHub Deployment
-    required: false
   token:
     description: GitHub token, required if service is set
     required: false

--- a/environment-matrix/src/main.ts
+++ b/environment-matrix/src/main.ts
@@ -4,7 +4,6 @@ import { run } from './run.js'
 const main = async (): Promise<void> => {
   const outputs = await run({
     rules: core.getInput('rules', { required: true }),
-    service: core.getInput('service'),
     token: core.getInput('token'),
   })
   core.setOutput('json', outputs.environments)

--- a/environment-matrix/src/main.ts
+++ b/environment-matrix/src/main.ts
@@ -6,7 +6,7 @@ const main = async (): Promise<void> => {
     rules: core.getInput('rules', { required: true }),
     token: core.getInput('token'),
   })
-  core.setOutput('json', outputs.environments)
+  core.setOutput('json', outputs.json)
 }
 
 main().catch((e: Error) => {

--- a/environment-matrix/src/rule.ts
+++ b/environment-matrix/src/rule.ts
@@ -1,11 +1,37 @@
 import * as yaml from 'js-yaml'
 import Ajv, { JTDSchemaType } from 'ajv/dist/jtd'
 
-export type Environment = Record<string, string>
+export type Outputs = Record<string, string>
 
-const EnvironmentSchema: JTDSchemaType<Environment> = {
+const OutputsSchema: JTDSchemaType<Outputs> = {
   values: {
     type: 'string',
+  },
+}
+
+export type GitHubDeployment = {
+  environment: string
+}
+
+const GitHubDeploymentSchema: JTDSchemaType<GitHubDeployment> = {
+  properties: {
+    environment: {
+      type: 'string',
+    },
+  },
+}
+
+export type Environment = {
+  outputs: Outputs
+  'github-deployment'?: GitHubDeployment
+}
+
+const EnvironmentSchema: JTDSchemaType<Environment> = {
+  properties: {
+    outputs: OutputsSchema,
+  },
+  optionalProperties: {
+    'github-deployment': GitHubDeploymentSchema,
   },
 }
 

--- a/environment-matrix/src/run.ts
+++ b/environment-matrix/src/run.ts
@@ -11,7 +11,7 @@ type Inputs = {
 }
 
 type Outputs = {
-  environments: Environment[]
+  json: rule.Outputs[]
 }
 
 type Environment = rule.Environment & {
@@ -41,5 +41,7 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
   core.startGroup('Environments')
   core.info(JSON.stringify(environments, undefined, 2))
   core.endGroup()
-  return { environments }
+  return {
+    json: environments.map((environment) => environment.outputs),
+  }
 }

--- a/environment-matrix/src/run.ts
+++ b/environment-matrix/src/run.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import * as rule from './rule.js'
-import * as matcher from './matcher.js'
+import { parseRulesYAML } from './rule.js'
+import { find } from './matcher.js'
 import { createDeployment } from './deployment.js'
 import { getOctokit } from './github.js'
 
@@ -11,16 +11,16 @@ type Inputs = {
 }
 
 type Outputs = {
-  json: rule.Outputs[]
+  json: Record<string, string>[]
 }
 
 export const run = async (inputs: Inputs): Promise<Outputs> => {
-  const rules = rule.parseRulesYAML(inputs.rules)
+  const rules = parseRulesYAML(inputs.rules)
   core.startGroup('Rules')
   core.info(JSON.stringify(rules, undefined, 2))
   core.endGroup()
 
-  const environments = matcher.find(github.context, rules)
+  const environments = find(github.context, rules)
   if (environments === undefined) {
     throw new Error(`no environment to deploy`)
   }

--- a/environment-matrix/src/run.ts
+++ b/environment-matrix/src/run.ts
@@ -14,17 +14,13 @@ type Outputs = {
   json: rule.Outputs[]
 }
 
-type Environment = rule.Environment & {
-  'github-deployment-url'?: string
-}
-
 export const run = async (inputs: Inputs): Promise<Outputs> => {
   const rules = rule.parseRulesYAML(inputs.rules)
   core.startGroup('Rules')
   core.info(JSON.stringify(rules, undefined, 2))
   core.endGroup()
 
-  const environments: Environment[] | undefined = matcher.find(github.context, rules)
+  const environments = matcher.find(github.context, rules)
   if (environments === undefined) {
     throw new Error(`no environment to deploy`)
   }
@@ -34,7 +30,7 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
   for (const environment of environments) {
     if (environment['github-deployment']) {
       const deployment = await createDeployment(octokit, github.context, environment['github-deployment'])
-      environment['github-deployment-url'] = deployment.url
+      environment.outputs['github-deployment-url'] = deployment.url
     }
   }
 

--- a/environment-matrix/tests/matcher.test.ts
+++ b/environment-matrix/tests/matcher.test.ts
@@ -9,8 +9,10 @@ const rules: Rules = [
     },
     environments: [
       {
-        overlay: 'pr',
-        namespace: 'pr-2',
+        outputs: {
+          overlay: 'pr',
+          namespace: 'pr-2',
+        },
       },
     ],
   },
@@ -21,8 +23,10 @@ const rules: Rules = [
     },
     environments: [
       {
-        overlay: 'pr',
-        namespace: 'pr-1',
+        outputs: {
+          overlay: 'pr',
+          namespace: 'pr-1',
+        },
       },
     ],
   },
@@ -32,8 +36,10 @@ const rules: Rules = [
     },
     environments: [
       {
-        overlay: 'development',
-        namespace: 'development',
+        outputs: {
+          overlay: 'development',
+          namespace: 'development',
+        },
       },
     ],
   },
@@ -53,8 +59,10 @@ test('pull_request with any branches', () => {
   }
   expect(find(context, rules)).toStrictEqual([
     {
-      overlay: 'pr',
-      namespace: 'pr-1',
+      outputs: {
+        overlay: 'pr',
+        namespace: 'pr-1',
+      },
     },
   ])
 })
@@ -73,8 +81,10 @@ test('pull_request with patterns', () => {
   }
   expect(find(context, rules)).toStrictEqual([
     {
-      overlay: 'pr',
-      namespace: 'pr-2',
+      outputs: {
+        overlay: 'pr',
+        namespace: 'pr-2',
+      },
     },
   ])
 })
@@ -87,8 +97,10 @@ test('push', () => {
   }
   expect(find(context, rules)).toStrictEqual([
     {
-      overlay: 'development',
-      namespace: 'development',
+      outputs: {
+        overlay: 'development',
+        namespace: 'development',
+      },
     },
   ])
 })


### PR DESCRIPTION
今後の拡張性を持たせるため、environment-matrix action の YAML スキーマを下記のように変更します。

### 階層の追加
出力値を指定している `environments` に `outputs` という階層を追加します。

Before:

```yaml
- uses: quipper/monorepo-deploy-actions/environment-matrix@v1
  with:
    rules: |
      - pull_request:
          base: '**'
          head: '**'
        environments:
          - overlay: pr
            namespace: pr-${{ github.event.pull_request.number }}
```

After:

```yaml
- uses: quipper/monorepo-deploy-actions/environment-matrix@v1
  with:
    rules: |
      - pull_request:
          base: '**'
          head: '**'
        environments:
          - outputs: # この階層を追加します
              overlay: pr
              namespace: pr-${{ github.event.pull_request.number }}
```

### GitHub Deployment オプションの変更
Before:

```yaml
- uses: quipper/monorepo-deploy-actions/environment-matrix@v1
  with:
    service: example # ここで値が指定されている場合は GitHub Deployment が作成されます
    rules: |
      - pull_request:
          base: '**'
          head: '**'
        environments:
          - overlay: pr
            namespace: pr-${{ github.event.pull_request.number }}
```

After:

```yaml
- uses: quipper/monorepo-deploy-actions/environment-matrix@v1
  with:
    rules: |
      - pull_request:
          base: '**'
          head: '**'
        environments:
          - github-deployment: # ここで値が指定されている場合は GitHub Deployment が作成されます
              environment: pr-${{ github.event.pull_request.number }}/example
            outputs:
              overlay: pr
              namespace: pr-${{ github.event.pull_request.number }}
```

## Internal issue
- https://github.com/quipper/quipper/issues/34707
