### PR TITLE
Remove backward compatibility support (bootstrap-pull-request)

### DIFF
--- a/bootstrap-pull-request/src/prebuilt.ts
+++ b/bootstrap-pull-request/src/prebuilt.ts
@@ -90,18 +90,12 @@ const deleteOutdatedApplicationManifest = async (
 
   // bootstrap-pull-request action needs to be run after git-push-service action.
   // See https://github.com/quipper/monorepo-deploy-actions/pull/1763 for the details.
-  if (application.metadata.annotations['github.action'] === 'git-push-service') {
-    if (application.metadata.annotations['github.head-sha'] === currentHeadSha) {
-      core.info(`Preserving the application manifest: ${applicationManifestPath}`)
-      return
-    }
-    // For the backward compatibility.
-    // Before https://github.com/quipper/monorepo-deploy-actions/pull/1768, the head SHA was not recorded.
-    // When this action is called for an old pull request, we assume that the application manifest was pushed on the current commit.
-    if (application.metadata.annotations['github.head-sha'] === undefined) {
-      core.info(`Preserving the application manifest: ${applicationManifestPath}`)
-      return
-    }
+  if (
+    application.metadata.annotations['github.action'] === 'git-push-service' &&
+    application.metadata.annotations['github.head-sha'] === currentHeadSha
+  ) {
+    core.info(`Preserving the application manifest: ${applicationManifestPath}`)
+    return
   }
 
   core.info(`Deleting the outdated application manifest: ${applicationManifestPath}`)

--- a/bootstrap-pull-request/tests/prebuilt.test.ts
+++ b/bootstrap-pull-request/tests/prebuilt.test.ts
@@ -243,46 +243,6 @@ describe('syncServicesFromPrebuilt', () => {
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationA)
     expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
   })
-
-  it('preserves a service if it was pushed by old implementation of git-push-action', async () => {
-    const namespaceDirectory = await createEmptyDirectory()
-    await fs.mkdir(`${namespaceDirectory}/applications`)
-    await fs.mkdir(`${namespaceDirectory}/services/a`, { recursive: true })
-    await fs.writeFile(`${namespaceDirectory}/applications/pr-123--a.yaml`, applicationPushedWithoutSha)
-    await fs.writeFile(`${namespaceDirectory}/services/a/generated.yaml`, 'this-should-be-kept')
-
-    const services = await syncServicesFromPrebuilt({
-      currentHeadSha: 'current-sha',
-      overlay: 'pr',
-      namespace: 'pr-123',
-      sourceRepositoryName: 'source-repository',
-      destinationRepository: 'octocat/destination-repository',
-      prebuiltBranch: 'prebuilt/source-repository/pr',
-      prebuiltDirectory: `${__dirname}/fixtures/prebuilt`,
-      namespaceDirectory,
-      substituteVariables: new Map<string, string>([['NAMESPACE', 'pr-123']]),
-      excludeServices: [],
-      invertExcludeServices: false,
-    })
-
-    expect(services).toStrictEqual<Service[]>([
-      { service: 'a', builtFrom: { pullRequest: { headRef: undefined, headSha: undefined } } },
-      {
-        service: 'b',
-        builtFrom: {
-          prebuilt: {
-            prebuiltBranch: 'prebuilt/source-repository/pr',
-            builtFrom: { headRef: 'main', headSha: 'main-branch-sha' },
-          },
-        },
-      },
-    ])
-    expect(await fs.readdir(`${namespaceDirectory}/applications`)).toStrictEqual(['pr-123--a.yaml', 'pr-123--b.yaml'])
-    expect(await readContent(`${namespaceDirectory}/applications/pr-123--a.yaml`)).toBe(applicationPushedWithoutSha)
-    expect(await readContent(`${namespaceDirectory}/services/a/generated.yaml`)).toBe('this-should-be-kept')
-    expect(await readContent(`${namespaceDirectory}/applications/pr-123--b.yaml`)).toBe(applicationB)
-    expect(await readContent(`${namespaceDirectory}/services/b/generated.yaml`)).toBe(serviceB)
-  })
 })
 
 const applicationA = `\
@@ -324,32 +284,6 @@ metadata:
     github.action: git-push-service
     github.head-ref: topic-branch
     github.head-sha: current-sha
-spec:
-  project: source-repository
-  source:
-    repoURL: https://github.com/octocat/destination-repository.git
-    targetRevision: ns/source-repository/pr/pr-123
-    path: services/a
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: pr-123
-  syncPolicy:
-    automated:
-      prune: true
-`
-
-// For the backward compatibility.
-const applicationPushedWithoutSha = `\
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: pr-123--a
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-  annotations:
-    github.action: git-push-service
-    github.sha: this-annotation-was-used-in-the-old-implementation
 spec:
   project: source-repository
   source:


### PR DESCRIPTION
https://github.com/quipper/monorepo-deploy-actions/pull/1768 をリリースしてから1ヶ月程度が経過したため、後方互換性の条件分岐を削除します。

現状では、namespace branch に下記形式のアノテーションが残っている場合、古いマニフェストが永遠に残ってしまう問題があります。この変更により、新しい prebuilt manifest で上書きされるようになります。

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    github.ref: refs/pull/18769/merge
    github.sha: 4b74108b6c29adf245d3b2bb01375a407459a6c1
    github.action: git-push-service
```

## Internal ref
https://quipper.slack.com/archives/C50FYM9BL/p1741326791219999?thread_ts=1741320719.446879&cid=C50FYM9BL
