### PR TITLE
chore: hold typescript major update until @vercel/ncc supports TypeScript 7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,16 @@
         "!@actions/*",
         "!pnpm"
       ]
+    },
+    {
+      "description": "Hold typescript major update: @vercel/ncc's ts-loader calls ts.sys.fileExists, which TypeScript 7 doesn't expose yet (no compiler API), so every build fails with 'Cannot read properties of undefined (reading fileExists)'",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- typescript の major update を renovate.json で一時的にブロック(minor/patchには影響しない)
- 現状の TypeScript 7.0 は Compiler API を公開しておらず(7.1で復活予定)、`@vercel/ncc` の ts-loader がビルド時に `TypeError: Cannot read properties of undefined (reading 'fileExists')` で全action共通に失敗するため
- 該当issue: vercel/ncc#1336 (Typescript 7 support、未対応)
- 現在オープン中の typescript v7 系 Renovate PR (#3230-#3239) は全件この原因でCI失敗しており、本設定変更後の次回 Renovate run で自動closeされる見込み

## Background
Renovate が typescript を v6.0.3 → v7.0.2 に上げる PR を10件作成したが、全件で e2e-test / test が同一エラーで失敗していた。調査の結果、TypeScript 7.0 自体が過渡期でCompiler APIを提供しておらず、`@vercel/ncc` 側がまだ対応していないことが根本原因と判明。ncc側の対応(vercel/ncc#1336)を待つ必要があるため、typescriptのmajor updateのみ一時的にignoreする。